### PR TITLE
Fix for "Discover" + Generic support for http-statuses and redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ let reactHandler = async (req, res) => {
 
   match({ routes, location }, async (error, redirectLocation, renderProps) => {
     if (redirectLocation) {
-      res.redirect(301, redirectLocation.pathname + redirectLocation.search)
+      res.redirect(307, redirectLocation.pathname + redirectLocation.search)
     } else if (error) {
       res.status(500).send(error.message)
     } else if (renderProps == null) {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -47,6 +47,7 @@ export const REMOVE_ALL_MESSAGES = 'REMOVE_ALL_MESSAGES';
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
 export const SET_CURRENT_USER = 'SET_CURRENT_USER';
 export const SET_SUGGESTED_USERS = 'SET_SUGGESTED_USERS';
+export const SET_PERSONALIZED_SUGGESTED_USERS = 'SET_PERSONALIZED_SUGGESTED_USERS';
 
 export const SET_COUNTRIES = 'SET_COUNTRIES';
 export const ADD_COUNTRY = 'ADD_COUNTRY';
@@ -265,6 +266,13 @@ export function setCurrentUser(user) {
 export function setSuggestedUsers(suggested_users) {
   return {
     type: SET_SUGGESTED_USERS,
+    suggested_users
+  }
+}
+
+export function setPersonalizedSuggestedUsers(suggested_users) {
+  return {
+    type: SET_PERSONALIZED_SUGGESTED_USERS,
     suggested_users
   }
 }

--- a/src/api/controller.js
+++ b/src/api/controller.js
@@ -888,14 +888,14 @@ export default class ApiController {
       .select('followers.following_user_id')
       .from('followers')
       .where('followers.user_id', '=', req.session.user)
-      .map(row => row.id);
+      .map(row => row.following_user_id);
 
     let User = this.bookshelf.model('User');
 
     let q = User.forge()
       .query(qb => {
         qb
-          .select('active_users.*', 'followers.user_id', 'followers.following_user_id')
+          .select('active_users.*')
           .from(function(){
             this.select('users.*')
               .count('posts.id as post_count')
@@ -912,7 +912,7 @@ export default class ApiController {
           .limit(6);
       });
 
-    let suggestions = await q.fetchAll({require: true, withRelated: ['following', 'followers', 'liked_posts', 'favourited_posts']});
+    let suggestions = await q.fetchAll({withRelated: ['following', 'followers', 'liked_posts', 'favourited_posts']});
 
     res.send(suggestions);
   }

--- a/src/components/user-grid.js
+++ b/src/components/user-grid.js
@@ -1,0 +1,59 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2015  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+
+import FollowButton from './follow-button';
+import User from './user';
+
+
+export const UserGrid = (props) => {
+  const {
+    current_user,
+    i_am_following,
+    triggers,
+    users
+  } = props;
+
+  if (!users) {
+    return <script/>;
+  }
+
+  return (
+    <div className="layout__grids layout__grids-space layout__grid-responsive">
+      {users.map((user) => (
+        <div className="layout__grids_item layout__grids_item-space layout__grid_item-50" key={`user-${user.id}`}>
+          <div className="layout__row layout__row-small">
+            <User
+              user={user}
+              avatarSize="32"
+            />
+          </div>
+
+          <div className="layout__row layout__row-small">
+            <FollowButton
+              active_user={current_user}
+              following={i_am_following}
+              triggers={triggers}
+              user={user}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/pages/auth.js
+++ b/src/pages/auth.js
@@ -17,7 +17,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
 
 import ApiClient from '../api/client'
 import { API_HOST } from '../config';
@@ -28,110 +27,82 @@ import Login from '../components/login';
 import Register from '../components/register';
 import Header from '../components/header';
 import Messages from '../components/messages';
-import Suggestions from './suggestions';
-import Message from '../components/message';
 
-let FirstLogin = () => (
-  <Message>
-    You are now successfully registered and logged in. You can proceed to <Link className="link" to="/induction">the next step</Link>
-  </Message>
-);
-
-let AuthContents = (props) => {
-
-  let {
-    current_user,
-    is_logged_in,
-    is_first_login,
-    triggers,
-    messages,
-    registration_success
-  } = props;
-  let render = {};
-
-  if(is_logged_in && !is_first_login){
-    return <Suggestions/>;
-  }
-
-  if (messages.length) {
-    render.messages = (
-      <div className="page__messages">
-        <div className="page__body page__body-small">
-          <Messages messages={messages} removeMessage={triggers.removeMessage} />
-        </div>
-      </div>
-    );
-  }
-
-  render.content = <FirstLogin/>;
-
-  if (!is_logged_in) {
-    render.headerLogin = <Login onLoginUser={triggers.login} />;
-    render.content = <Register
-        onRegisterUser={triggers.registerUser}
-        registration_success={registration_success}
-        onShowRegisterForm={triggers.showRegisterForm}
-      />;
-  }
-
-  return (
-    <div className="page__container-bg font-open_sans font-light">
-      <section className="landing landing-big landing-bg landing-bg_house">
-        <Header
-          is_logged_in={is_logged_in}
-          current_user={current_user}
-          className="header-transparent header-transparent_border"
-        />
-        <header className="landing__body">
-            <p className="layout__row layout__row-small landing__small_title" style={{ position: 'relative', left: 4 }}>Welcome to LibertySoil.org</p>
-            <h1 className="landing__subtitle landing__subtitle-narrow">Education change network</h1>
-            {render.headerLogin}
-        </header>
-      </section>
-      {render.messages}
-      <div className="page__content page__content-spacing">
-        <div className="page__body page__body-small">
-          <div className="layout__row">
-            {render.content}
-          </div>
-        </div>
-      </div>
-      <Footer/>
-    </div>
-  );
-};
 
 class Auth extends React.Component {
+  static async fetchData(params, store) {
+    const props = store.getState();
+    const currentUserId = props.get('current_user').get('id');
+    const isLoggedIn = (currentUserId !== null);
 
-  contextTypes: {
-    router: React.PropTypes.object.isRequired
+    if (!isLoggedIn) {
+      return null;
+    }
+
+    const currentUser = props.get('users').get(currentUserId);
+    const more = currentUser.get('more');
+    const is_first_login = !more || more.get('first_login');
+
+    if (is_first_login) {
+      return {status: 307, redirectTo: '/induction'};
+    }
+
+    return {status: 307, redirectTo: '/'};
   }
-
 
   render() {
     let { current_user, is_logged_in, messages, ui } = this.props;
 
     const client = new ApiClient(API_HOST);
     const triggers = new ActionsTrigger(client, this.props.dispatch);
-    const registration_success = ui.registrationSuccess;
 
-    let is_first_login = false;
-    if (current_user) {
-      if (current_user.more) {
-        is_first_login = current_user.more.first_login;
-      }
+    let render = {};
+
+    if (messages.length) {
+      render.messages = (
+        <div className="page__messages">
+          <div className="page__body page__body-small">
+            <Messages messages={messages} removeMessage={triggers.removeMessage} />
+          </div>
+        </div>
+      );
     }
 
+    const registration_success = ui.registrationSuccess;
+
     return (
-      <AuthContents
-        current_user={current_user}
-        is_logged_in={is_logged_in}
-        is_first_login={is_first_login}
-        triggers={triggers}
-        messages={messages}
-        registration_success={registration_success}
-        />
-    )
+      <div className="page__container-bg font-open_sans font-light">
+        <section className="landing landing-big landing-bg landing-bg_house">
+          <Header
+            is_logged_in={is_logged_in}
+            current_user={current_user}
+            className="header-transparent header-transparent_border"
+          />
+
+          <header className="landing__body">
+            <p className="layout__row layout__row-small landing__small_title" style={{ position: 'relative', left: 4 }}>Welcome to LibertySoil.org</p>
+            <h1 className="landing__subtitle landing__subtitle-narrow">Education change network</h1>
+            <Login onLoginUser={triggers.login} />
+          </header>
+        </section>
+
+        {render.messages}
+
+        <div className="page__content page__content-spacing">
+          <div className="page__body page__body-small">
+            <div className="layout__row">
+              <Register
+                registration_success={registration_success}
+                onShowRegisterForm={triggers.showRegisterForm}
+                onRegisterUser={triggers.registerUser}
+              />
+            </div>
+          </div>
+        </div>
+
+        <Footer/>
+      </div>
+    );
   }
 }
 

--- a/src/pages/induction.js
+++ b/src/pages/induction.js
@@ -20,10 +20,9 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
 import BaseInductionPage from './base/induction';
-import User from '../components/user';
-import FollowButton from '../components/follow-button';
 import Footer from '../components/footer';
 import Header from '../components/header';
+import { UserGrid } from '../components/user-grid';
 import ApiClient from '../api/client';
 import { API_HOST } from '../config';
 import { addUser } from '../actions';
@@ -42,47 +41,6 @@ let InductionDone = () => (
     </div>
   </div>
 );
-
-export default class UserGrid extends React.Component {
-  static displayName = 'UserGrid'
-
-  render () {
-    const {
-      users,
-      current_user,
-      i_am_following,
-      triggers
-    } = this.props;
-
-    if (!users) {
-      return null;
-    }
-
-    return (
-      <div className="layout__grids layout__grids-space layout__grid-responsive">
-        {users.map((user) => (
-          <div className="layout__grids_item layout__grids_item-space layout__grid_item-50" key={user.id}>
-            <div className="layout__row layout__row-small">
-              <User
-                user={user}
-                avatarSize="32"
-              />
-            </div>
-
-            <div className="layout__row layout__row-small">
-              <FollowButton
-                active_user={current_user}
-                following={i_am_following}
-                triggers={triggers}
-                user={user}
-              />
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-}
 
 class InductionPage extends React.Component {
   static displayName = 'InductionPage'

--- a/src/pages/suggestions.js
+++ b/src/pages/suggestions.js
@@ -23,29 +23,34 @@ import BaseSuggestionsPage from './base/suggestions';
 import { UserGrid } from '../components/user-grid';
 import ApiClient from '../api/client';
 import { API_HOST } from '../config';
-import { addUser } from '../actions';
 import { ActionsTrigger } from '../triggers'
 import { defaultSelector } from '../selectors';
 
 
+const DiscoverGrid = (props) => {
+  if (props.users.length === 0) {
+    return <script/>;
+  }
+
+  return (
+    <div className="paper__page">
+      <h2 className="content__sub_title layout__row">Discover</h2>
+      <div className="layout__row layout__row-double">
+        <UserGrid
+          current_user={props.current_user}
+          i_am_following={props.i_am_following}
+          triggers={props.triggers}
+          users={props.users}
+        />
+      </div>
+    </div>
+  );
+};
+
 class SuggestionsPage extends React.Component {
-  static displayName = 'SettingsPasswordPage'
-
   static async fetchData(params, store, client) {
-    const props = store.getState();
-    const currentUserId = props.get('current_user').get('id');
-
-    if (currentUserId === null) {
-      return;
-    }
-
-    let currentUser = props.get('users').get(currentUserId);
-    let suggestedUsers = await client.userSuggestions();
-
-    let userInfo = client.userInfo(currentUser.get('username'));
-    userInfo.more.suggested_users = suggestedUsers;
-
-    store.dispatch(addUser(userInfo));
+    let triggers = new ActionsTrigger(client, store.dispatch);
+    await triggers.loadPersonalizedSuggestions();
   }
 
   render() {
@@ -53,8 +58,7 @@ class SuggestionsPage extends React.Component {
       current_user,
       is_logged_in,
       i_am_following,
-      messages,
-      ...props
+      messages
     } = this.props;
 
     if (!is_logged_in) {
@@ -76,17 +80,12 @@ class SuggestionsPage extends React.Component {
           <p>You are logged in. You can proceed to <Link className="link" to="/">your feed</Link>.</p>
         </div>
 
-        <div className="paper__page">
-          <h2 className="content__sub_title layout__row">Discover</h2>
-          <div className="layout__row layout__row-double">
-            <UserGrid
-              current_user={current_user}
-              i_am_following={i_am_following}
-              triggers={triggers}
-              users={current_user.more.suggested_users}
-            />
-          </div>
-        </div>
+        <DiscoverGrid
+          current_user={current_user}
+          i_am_following={i_am_following}
+          triggers={triggers}
+          users={current_user.suggested_users}
+        />
       </BaseSuggestionsPage>
     )
   }

--- a/src/pages/suggestions.js
+++ b/src/pages/suggestions.js
@@ -20,56 +20,13 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
 import BaseSuggestionsPage from './base/suggestions';
-import User from '../components/user';
-import FollowButton from '../components/follow-button';
-
+import { UserGrid } from '../components/user-grid';
 import ApiClient from '../api/client';
 import { API_HOST } from '../config';
 import { addUser } from '../actions';
 import { ActionsTrigger } from '../triggers'
 import { defaultSelector } from '../selectors';
 
-
-export default class UserGrid extends React.Component {
-  static displayName = 'UserGrid'
-
-  render () {
-    const {
-      users,
-      current_user,
-      i_am_following,
-      triggers
-    } = this.props;
-
-    if (!users) {
-      return false;
-    }
-
-    return (
-      <div className="layout__grids layout__grids-space layout__grid-responsive">
-        {users.map((user) => (
-          <div className="layout__grids_item layout__grids_item-space layout__grid_item-50" key={`user-${user.id}`}>
-            <div className="layout__row layout__row-small">
-              <User
-                user={user}
-                avatarSize="32"
-              />
-            </div>
-
-            <div className="layout__row layout__row-small">
-              <FollowButton
-                active_user={current_user}
-                following={i_am_following}
-                triggers={triggers}
-                user={user}
-              />
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-}
 
 class SuggestionsPage extends React.Component {
   static displayName = 'SettingsPasswordPage'

--- a/src/routing.js
+++ b/src/routing.js
@@ -35,6 +35,7 @@ import SchoolEditPage from './pages/school-edit';
 import SettingsPage from './pages/settings';
 import SettingsPasswordPage from './pages/settings-password';
 import SettingsFollowersPage from './pages/settings-followers';
+import SuggestionsPage from './pages/suggestions';
 import TagPage from './pages/tag';
 import TagCloudPage from './pages/tag-cloud';
 import CityPage from './pages/city';
@@ -58,6 +59,7 @@ export function getRoutes(authHandler, fetchHandler) {
     <Route component={App}>
       <Route component={List} path="/" onEnter={withAuth} />
       <Route component={Induction} path="/induction" onEnter={withAuth} />
+      <Route component={SuggestionsPage} path="/suggestions" onEnter={withAuth} />
       <Route component={Welcome} path="/welcome" onEnter={withoutAuth} />
       <Route component={Auth} path="/auth" onEnter={withoutAuth} />
       <Route component={PostPage} path="/post/:uuid" onEnter={withoutAuth} />

--- a/src/store/current-user.js
+++ b/src/store/current-user.js
@@ -26,6 +26,7 @@ const initialState = i.Map({
   tags: i.List([]),
   followed_tags: i.Map({}),
   followed_schools: i.Map({}),
+  suggested_users: i.List([])
 });
 
 export default function reducer(state=initialState, action) {
@@ -43,6 +44,7 @@ export default function reducer(state=initialState, action) {
           .set('tags', i.List([]))
           .set('followed_tags', i.Map({}))
           .set('followed_schools', i.Map({}))
+          .set('suggested_users', i.List([]));
       });
 
       break;
@@ -101,6 +103,12 @@ export default function reducer(state=initialState, action) {
 
     case a.REMOVE_USER_FOLLOWED_SCHOOL: {
       state = state.deleteIn(['followed_schools', action.school.url_name]);
+
+      break;
+    }
+
+    case a.SET_PERSONALIZED_SUGGESTED_USERS: {
+      state = state.set('suggested_users', i.fromJS(action.suggested_users));
 
       break;
     }

--- a/src/store/current-user.js
+++ b/src/store/current-user.js
@@ -23,25 +23,26 @@ import * as a from '../actions';
 
 const initialState = i.Map({
   id: null,
-  tags: i.List([])
+  tags: i.List([]),
+  followed_tags: i.Map({}),
+  followed_schools: i.Map({}),
 });
 
 export default function reducer(state=initialState, action) {
   switch (action.type) {
-    case a.SET_CURRENT_USER:
-    {
+    case a.SET_CURRENT_USER: {
       const oldUid = state.get('id');
 
       if (!action.user || oldUid === action.user.id) {
-
         break;
       }
 
-      state = state.withMutations(function (state) {
+      state = state.withMutations((state) => {
         state
           .set('id', action.user.id)
           .set('tags', i.List([]))
-          .set('followed_tags', i.Map({}));
+          .set('followed_tags', i.Map({}))
+          .set('followed_schools', i.Map({}))
       });
 
       break;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -72,7 +72,8 @@ const initialState = i.Map({
     id: null,
     tags: i.List([]),
     followed_tags: i.Map({}),
-    followed_schools: i.Map({})
+    followed_schools: i.Map({}),
+    suggested_users: i.List([])
   }),
   create_post_form: i.fromJS({
     text: '',

--- a/src/triggers/index.js
+++ b/src/triggers/index.js
@@ -20,7 +20,7 @@ import {
   addError, addMessage, removeAllMessages,
   addUser, addPost, addPostToRiver, setCurrentUser, removePost,
   setLikes, setFavourites, setPostsToLikesRiver,
-  setUserTags, setSchools, addSchool, setSuggestedUsers, setPostsToRiver,
+  setUserTags, setSchools, addSchool, setSuggestedUsers, setPersonalizedSuggestedUsers, setPostsToRiver,
   submitResetPassword, submitNewPassword, setTagCloud, addUserFollowedTag,
   removeUserFollowedTag, addUserFollowedSchool, removeUserFollowedSchool,
   removeMessage, registrationSuccess, showRegisterForm
@@ -301,6 +301,18 @@ export class ActionsTrigger {
       let result = await this.client.initialSuggestions();
 
       this.dispatch(setSuggestedUsers(result));
+
+      return result;
+    } catch (e) {
+      this.dispatch(addError(e.message));
+    }
+  };
+
+  loadPersonalizedSuggestions = async () => {
+    try {
+      let result = await this.client.userSuggestions();
+
+      this.dispatch(setPersonalizedSuggestedUsers(result));
 
       return result;
     } catch (e) {

--- a/test-helpers/expect.js
+++ b/test-helpers/expect.js
@@ -37,7 +37,7 @@ expect.addAssertion('to redirect', function (expect, subject, value) {
   return expect(app, 'to yield exchange', {
     request: subjectToRequest(subject),
     response: {
-      statusCode: 301
+      statusCode: 307
     }
   });
 });


### PR DESCRIPTION
1. `return 404` will set custom http-status for server-response on the server-side (works for ANY status code)
2. `return {status: 307, redirectTo: '/some/url'}` will cause redirect both on client-side (via html5-history API) and server-side (via hard http redirect)
- It is moved to separate URL
- Its data is stored inside of a separate key, not clobbering user's object
- Corresponding API-method works reliably now