### PR TITLE
Fixed undefined class of header, made its position correct (top)

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -61,7 +61,10 @@ export default class HeaderComponent extends React.Component {
       children
     } = this.props;
 
-    let classNames = 'header page__header ' + this.props.className;
+    let classNames = 'header page__header header-top';
+    if (this.props.className) {
+      classNames += ' ' + this.props.className;
+    }
 
     return (
       <div {...this.props} className={classNames}>

--- a/src/less/blocks/header.less
+++ b/src/less/blocks/header.less
@@ -27,6 +27,11 @@
   &-transparent_border {
     border-color: transparent;
   }
+  
+  &-top {
+    position: relative;
+    z-index: 999;
+  }
 
   &-fixed {
     position: fixed;


### PR DESCRIPTION
Header's position in user page (for example) was wrong (it was under the page content). So users couldn't log out. Fixed.
Also fixed the problem with header's `undefined` class if `this.props.className` hadn't been defined.