### PR TITLE
Add compatibility with page-less posts

### DIFF
--- a/migrations/20160303194045_post-urlname.js
+++ b/migrations/20160303194045_post-urlname.js
@@ -17,6 +17,10 @@ export async function up(knex, Promise) {
   const result = await posts.fetch({withRelated: ['user']});
 
   for (const post of result.models) {
+    if (Post.typesWithoutPages.includes(post.get('type'))) {
+      continue;
+    }
+
     const title = await Post.titleFromText(post.get('text'), post.related('user').get('fullName'));
     const urlName = `${slug(title)}-${post.get('id')}`;
 

--- a/src/api/controller.js
+++ b/src/api/controller.js
@@ -1092,13 +1092,15 @@ export default class ApiController {
       obj.set('fully_published_at', new Date().toJSON());
     }
 
-    const author = await obj.related('user').fetch();
-    more.pageTitle = await Post.titleFromText(req.body.text, author.get('fullName'));
+    if (!Post.typesWithoutPages.includes(obj.get('type'))) {
+      const author = await obj.related('user').fetch();
+      more.pageTitle = await Post.titleFromText(req.body.text, author.get('fullName'));
+
+      const urlName = `${slug(more.pageTitle)}-${obj.id}`;
+      obj.set('url_name', urlName);
+    }
 
     obj.set('more', more);
-
-    const urlName = `${slug(more.pageTitle)}-${obj.id}`;
-    obj.set('url_name', urlName);
 
     try {
       await obj.save(null, {method: 'insert'});

--- a/src/api/db/index.js
+++ b/src/api/db/index.js
@@ -262,6 +262,7 @@ export function initBookshelfFromKnex(knex) {
     }
   });
 
+  Post.typesWithoutPages = ['geotag_like', 'school_like', 'hashtag_like'];
   Post.titleFromText = async (text, authorName) => {
     const get50 = async (text) => {
       const first50GraphemesOfText = breakGraphemes(text).slice(0, 51);


### PR DESCRIPTION
Likes of various tag-types generate special posts without text-contents. Fortunately, these posts do not have pages associated with them as well. So, this pull-requests stops trying to generate page-titles and urlnames for such posts