### PR TITLE
Fixed impossibility of set `first_login` to `false` in `updateUser()`

### DIFF
--- a/src/api/db/validators.js
+++ b/src/api/db/validators.js
@@ -59,7 +59,8 @@ let User = {
     more: {
       summary: ['string'],
       bio: ['string'],
-      roles: ['array']
+      roles: ['array'],
+      first_login: ['boolean']
     }
   }
 };


### PR DESCRIPTION
Trello: https://trello.com/c/Rkp5siIQ/420-issue-238-thank-you-for-registering-message-is-dispalyed-after-logged-in