### PR TITLE
Fixed incorrect school icon's link in school tag page

### DIFF
--- a/src/components/school-header.js
+++ b/src/components/school-header.js
@@ -55,7 +55,7 @@ export default class SchoolHeader extends React.Component {
     let toolbarSecondary = [];
 
     let name = school.url_name;
-    let updated_at = moment(school.updated_at).format('MMMM D, HH:MM');
+    let updated_at = moment(school.updated_at).format('MMMM D, HH:mm');
     let linesOfDescription = <p>No information provided...</p>;
 
     if (school.name) {
@@ -108,7 +108,7 @@ export default class SchoolHeader extends React.Component {
     return (
       <Panel
         title={name}
-        icon={<Tag size="BIG" type={TAG_SCHOOL} urlId={name} />}
+        icon={<Tag size="BIG" type={TAG_SCHOOL} urlId={school.url_name} />}
         toolbarPrimary={toolbarPrimary}
         toolbarSecondary={toolbarSecondary}
       >


### PR DESCRIPTION
Trello: https://trello.com/c/wl8jlhAk/414-issue-232-page-not-found-error-message-displayed-when-clicking-on-school-icon-at-school-tag-page