### PR TITLE
Remove undefined posts from the river

### DIFF
--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -53,8 +53,8 @@ export class TagPage extends Component {
   static displayName = 'TagPage';
 
   static async fetchData(params, store, client) {
-    let tagPosts = client.tagPosts(params.tag);
-    store.dispatch(setTagPosts(params.tag, await tagPosts));
+    let tagPosts = await client.tagPosts(params.tag);
+    store.dispatch(setTagPosts(params.tag, tagPosts));
   }
 
   render() {

--- a/src/store/tag_posts.js
+++ b/src/store/tag_posts.js
@@ -28,6 +28,17 @@ export default function reducer(state=initialState, action) {
       state = state.set(action.hashtag, i.List(action.posts.map(post => post.id)));
       break;
     }
+
+    case a.REMOVE_POST: {
+      for (let hashtagName of state.keys()) {
+        let idx = state.get(hashtagName).findIndex(hashtagPostId => (hashtagPostId === action.id));
+
+        if (idx >= 0) {
+          state = state.deleteIn([hashtagName, idx]);
+        }
+      }
+      break;
+    }
   }
 
   return state;


### PR DESCRIPTION
Create few posts that are related with one `hashtag` (important). Go to its page and delete one post. You'll be redirected to `News Feed` page. Go to tag's page again. You'll can see `Uncaught TypeError: Cannot read property 'type' of undefined` (`river_of_posts.js`, 37 line) message in console or (dev mode) red error screen about it.

The reason is that `this.props.posts` don't have an element with one `id` from `this.props.river`. (32 line).
Fixed with adding `REMOVE_POST` reducer for hashtag posts.