### PR TITLE
[Fix] users being able to like and fav their own posts

### DIFF
--- a/src/api/controller.js
+++ b/src/api/controller.js
@@ -275,7 +275,7 @@ export default class ApiController {
         .from('users')
         .where('users.username', '=', req.params.user)
         .map(row => row.id);
-      
+
       let posts = await this.getLikedPosts(user_id[0]);
       res.send(posts);
     } catch (e) {
@@ -529,7 +529,7 @@ export default class ApiController {
       let post = await Post.where({id: req.params.id}).fetch({require: true});
       let user = await User.where({id: req.session.user}).fetch({require: true, withRelated: ['liked_posts']});
 
-      if (post.user_id === user.id) {
+      if (post.get('user_id') === user.id) {
         res.status(403);
         res.send({error: "You can't like your own post"});
         return;
@@ -607,7 +607,7 @@ export default class ApiController {
       let post = await Post.where({id: req.params.id}).fetch({require: true});
       let user = await User.where({id: req.session.user}).fetch({require: true, withRelated: ['favourited_posts']});
 
-      if (post.user_id === user.id) {
+      if (post.get('user_id') === user.id) {
         res.status(403);
         res.send({error: "You can't add your own post to favorites"});
         return;

--- a/src/api/controller.js
+++ b/src/api/controller.js
@@ -529,6 +529,12 @@ export default class ApiController {
       let post = await Post.where({id: req.params.id}).fetch({require: true});
       let user = await User.where({id: req.session.user}).fetch({require: true, withRelated: ['liked_posts']});
 
+      if (post.user_id === user.id) {
+        res.status(403);
+        res.send({error: "You can't like your own post"});
+        return;
+      }
+
       await user.liked_posts().attach(post);
 
       post = await Post.where({id: req.params.id}).fetch({require: true, withRelated: ['likers']});
@@ -600,6 +606,12 @@ export default class ApiController {
     try {
       let post = await Post.where({id: req.params.id}).fetch({require: true});
       let user = await User.where({id: req.session.user}).fetch({require: true, withRelated: ['favourited_posts']});
+
+      if (post.user_id === user.id) {
+        res.status(403);
+        res.send({error: "You can't add your own post to favorites"});
+        return;
+      }
 
       await user.favourited_posts().attach(post);
 

--- a/test-helpers/expect.js
+++ b/test-helpers/expect.js
@@ -97,11 +97,13 @@ expect.addAssertion('to open authorized', function (expect, subject, value) {
 });
 
 expect.addAssertion('not to open authorized', function (expect, subject, value) {
+  expect.errorMode = 'bubble';
   return expect(subjectToRequest(subject), 'to yield response', {})
     .then(function (context) {
-    const status = context.httpResponse.statusLine.statusCode;
-    expect(status, 'to equal', 403);
-  });
+
+      const status = context.httpResponse.statusLine.statusCode;
+      expect(status, 'to equal', 403);
+    });
 });
 
 expect.addAssertion('to open not found', function (expect, subject, value) {

--- a/test/integration/api.js
+++ b/test/integration/api.js
@@ -287,11 +287,20 @@ describe('api v.1', () => {
         });
 
         describe('Favourites', () => {
+          let ownPost;
 
           beforeEach(async () => {
+            ownPost = new Post({
+              id: uuid4(),
+              type: POST_DEFAULT_TYPE,
+              text: `This is own post`,
+              user_id: user.id
+            });
+            await ownPost.save({}, {method: 'insert'});
           });
 
           afterEach(async () => {
+            await ownPost.destroy();
           });
 
           it('CAN fav post', async () => {
@@ -323,15 +332,31 @@ describe('api v.1', () => {
               'body to satisfy', [{text: 'This is clean post'}]
             );
           });
+
+          it('CAN NOT fav own post', async () => {
+            await expect(
+              { url: `/api/v1/post/${ownPost.id}/fav`, session: sessionId, method: 'POST' },
+              'not to open authorized'
+            );
+          });
         });
 
         describe('Likes', () => {
+          let ownPost;
 
           beforeEach(async () => {
+            ownPost = new Post({
+              id: uuid4(),
+              type: POST_DEFAULT_TYPE,
+              text: `This is own post`,
+              user_id: user.id
+            });
+            await ownPost.save({}, {method: 'insert'});
           });
 
           afterEach(async () => {
             await user.liked_posts().detach(post);
+            await ownPost.destroy();
           });
 
           it('CAN like post', async () => {
@@ -361,6 +386,13 @@ describe('api v.1', () => {
             await expect(
               { url: `/api/v1/posts/liked`, session: sessionId },
               'body to satisfy', [{text: 'This is clean post'}]
+            );
+          });
+
+          it('CAN NOT like own post', async () => {
+            await expect(
+              { url: `/api/v1/post/${ownPost.id}/fav`, session: sessionId, method: 'POST' },
+              'not to open authorized'
             );
           });
         });


### PR DESCRIPTION
#323 https://trello.com/c/HPga91JD/506-issue-323-server-api-should-not-allow-post-author-favourite-like-their-post

Fixed the `likePost` and `favPost` controllers.