### PR TITLE
Text in error message overlapped by "X" mark during registering

### DIFF
--- a/src/less/blocks/message.less
+++ b/src/less/blocks/message.less
@@ -23,7 +23,7 @@
   z-index: 10000;
 
   &__body {
-    padding: 16px 20px 16px 20px;
+    padding: 16px 35px 16px 20px;
     font-size: 16px;
     line-height: 22px;
     flex: 1;


### PR DESCRIPTION
Trello: https://trello.com/c/7zOXgaQH/562-text-in-error-message-overlapped-by-x-mark-during-registering