### PR TITLE
User component refactoring

### DIFF
--- a/src/components/auth-block.js
+++ b/src/components/auth-block.js
@@ -31,7 +31,7 @@ const AuthBlock = ({ current_user, is_logged_in }) => {
     return (
       <div className="header__toolbar">
         <div className="header__toolbar_item">
-          <User hideText isRound user={current_user.user} />
+          <User avatar={{ isRound: true }} text={{ hide: true }} user={current_user.user} />
           <Dropdown>
             <Link className="menu__item" to={getUrl(URL_NAMES.SETTINGS)}>Profile settings</Link>
             <form action={`${API_HOST}${logoutUrl}`} className="menu__item" method="post">

--- a/src/components/post/comment.js
+++ b/src/components/post/comment.js
@@ -1,6 +1,6 @@
 /*
  This file is a part of libertysoil.org website
- Copyright (C) 2015  Loki Education (Social Enterprise)
+ Copyright (C) 2016  Loki Education (Social Enterprise)
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as published by
@@ -14,11 +14,8 @@
 
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-import React, {
-  Component
-} from 'react';
+*/
+import React, { Component } from 'react';
 
 import Time from '../time';
 import User from '../user';
@@ -30,10 +27,14 @@ import MenuItem from '../menu-item';
 import paragraphify from '../../utils/paragraphify';
 
 export default class Comment extends Component {
-  state = {
-    text: '',
-    isEditMode: false
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      text: '',
+      isEditMode: false
+    };
+  }
 
   componentWillReceiveProps(nextProps) {
     const {
@@ -174,20 +175,20 @@ export default class Comment extends Component {
           </div>
           <div className="layout__row layout">
             <Button
-              disabled={!text.trim() || (commentUi && commentUi.isSaveInProgress)}
-              type="submit"
-              size="midi"
               className="layout__grid_item"
-              title="Save Comment"
               color="light_blue"
+              disabled={!text.trim() || (commentUi && commentUi.isSaveInProgress)}
+              size="midi"
+              title="Save Comment"
+              type="submit"
             />
             <Button
-              disabled={commentUi && commentUi.isSaveInProgress}
-              onClick={this.disableEditingComment}
               className="layout__grid_item"
-              title="Cancel"
               color="transparent"
+              disabled={commentUi && commentUi.isSaveInProgress}
               size="midi"
+              title="Cancel"
+              onClick={this.disableEditingComment}
             />
           </div>
         </form>
@@ -218,7 +219,7 @@ export default class Comment extends Component {
         <div className="comment__container">
           <header className="comment__header">
             <div className="comment__author">
-              <User user={author} avatarSize="17" hideText />
+              <User avatar={{ size: 17 }} text={{ hide: true }} user={author} />
             </div>
           </header>
           {this.renderBody()}

--- a/src/components/post/create-comment.js
+++ b/src/components/post/create-comment.js
@@ -1,6 +1,6 @@
 /*
  This file is a part of libertysoil.org website
- Copyright (C) 2015  Loki Education (Social Enterprise)
+ Copyright (C) 2016  Loki Education (Social Enterprise)
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as published by
@@ -14,11 +14,8 @@
 
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-import React, {
-    Component,
-    PropTypes
-} from 'react';
+*/
+import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 
 import bem from '../../utils/bemClassNames';
@@ -51,10 +48,14 @@ export default class CreateComment extends Component {
     className: ''
   };
 
-  state = {
-    isExpanded: false,
-    comment: ''
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isExpanded: false,
+      comment: ''
+    };
+  }
 
   componentWillReceiveProps(nextProps) {
     const {
@@ -159,8 +160,8 @@ export default class CreateComment extends Component {
         <div className="layout">
           <div className="layout__grid_item">
             <User
-              avatarSize="32"
-              hideText
+              avatar={{ size: 32 }}
+              text={{ hide: true }}
               user={author}
             />
           </div>

--- a/src/components/post/footer.js
+++ b/src/components/post/footer.js
@@ -34,7 +34,7 @@ const PostFooter = ({ author, current_user, post, triggers }) => {
     <div>
       <div className="card__meta">
         <div className="card__owner">
-          <User avatarSize="39" user={author} />
+          <User avatar={{ size: 39 }} user={author} />
         </div>
         <div className="card__timestamp">
           <Link to={post_url}>

--- a/src/components/post/short-post.js
+++ b/src/components/post/short-post.js
@@ -1,6 +1,6 @@
 /*
  This file is a part of libertysoil.org website
- Copyright (C) 2015  Loki Education (Social Enterprise)
+ Copyright (C) 2016  Loki Education (Social Enterprise)
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as published by
@@ -14,13 +14,12 @@
 
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 import React from 'react';
 import { Link } from 'react-router';
 
 import { URL_NAMES, getUrl } from '../../utils/urlGenerator';
 import User from '../user';
-
 
 const ShortPost = ({ post, author }) => (
   <div className="short_post short_post-spacing" key={post.id}>
@@ -28,7 +27,7 @@ const ShortPost = ({ post, author }) => (
       {post.text}
     </Link>
     <div className="short_post__author">
-      <User avatarSize="20" user={author} />
+      <User avatar={{ size: 20 }} user={author} />
     </div>
   </div>
 );

--- a/src/components/profile.js
+++ b/src/components/profile.js
@@ -183,11 +183,10 @@ export default class ProfileHeader extends React.Component {
             <div className="layout__grid">
               <div className="layout__grid_item layout__grid_item-wide">
                 <User
-                  avatarPreview={avatarPreview}
-                  avatarSize="120"
-                  editorConfig={editable ? { flexible: false, onUpdateAvatar: this.addAvatar } : false}
-                  hideText
-                  isRound
+                  avatar={{ url: avatarPreview && avatarPreview.url, size: 120, isRound: true }}
+                  avatarEditor={editable ? { flexible: false, onUpdateAvatar: this.addAvatar } : false}
+                  isLink={!editable}
+                  text={{ hide: true }}
                   user={user}
                 />
               </div>

--- a/src/components/side-suggested-users.js
+++ b/src/components/side-suggested-users.js
@@ -16,12 +16,11 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 import React, { PropTypes } from 'react';
-import _ from 'lodash';
+import { take } from 'lodash';
 
 import FollowButton from './follow-button';
 import IgnoreButton from './ignore-button';
 import User from './user';
-
 
 export default class SideSuggestedUsers extends React.Component {
   static displayName = 'SideSuggestedUsers';
@@ -83,11 +82,11 @@ export default class SideSuggestedUsers extends React.Component {
     return (
       <div className="side_block">
         <h4 className="side_block__heading">People to follow:</h4>
-        {_.take(users, 3).map((user) => (
+        {take(users, 3).map((user) => (
           <div className={className} key={`user-${user.id}`}>
             <div className="layout__row layout__row-small">
               <User
-                avatarSize="32"
+                avatar={{ size: 32 }}
                 user={user}
               />
             </div>
@@ -101,8 +100,8 @@ export default class SideSuggestedUsers extends React.Component {
               />
               <IgnoreButton
                 active_user={current_user}
-                onClick={this.ignoreUser}
                 user={user}
+                onClick={this.ignoreUser}
               />
             </div>
           </div>

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -1,6 +1,6 @@
 /*
  This file is a part of libertysoil.org website
- Copyright (C) 2015  Loki Education (Social Enterprise)
+ Copyright (C) 2016  Loki Education (Social Enterprise)
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as published by
@@ -14,13 +14,11 @@
 
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 import React from 'react';
-import {
-  values,
-  throttle
-} from 'lodash';
+import { values, throttle } from 'lodash';
 import { connect } from 'react-redux';
+import { Link } from 'react-router';
 
 import { toggleUISidebar } from '../actions';
 
@@ -162,9 +160,9 @@ class Sidebar extends React.Component {
           <h4 className="sidebar__heading">I post to</h4>
           <div className="sidebar__user_tags">
             <TagCloud
+              geotags={current_user.geotags}
               hashtags={current_user.hashtags}
               schools={current_user.schools}
-              geotags={current_user.geotags}
               truncated
             />
           </div>
@@ -175,24 +173,25 @@ class Sidebar extends React.Component {
     const username = current_user.user.username;
     const test = RegExp(`user\/${username}\/?$`);
     let currentUser;
+
     if (routing && routing.locationBeforeTransitions.pathname.match(test)) {
       currentUser = (
-        <NavigationItem enabled to={`/user/${username}`} className="sidebar__user">
-          <CurrentUser user={current_user.user} isLink={false} />
+        <NavigationItem className="sidebar__user" enabled to={`/user/${username}`}>
+          <CurrentUser isLink={false} user={current_user.user} />
         </NavigationItem>
       );
     } else {
       currentUser = (
-        <div className="navigation__item sidebar__user">
-          <CurrentUser user={current_user.user} />
-        </div>
+        <Link className="navigation__item sidebar__user" to={`/user/${username}`}>
+          <CurrentUser isLink={false} user={current_user.user} />
+        </Link>
       );
     }
 
     return (
       <div className={sidebarClassName.join(' ')}>
         <Navigation className="navigation-first">
-          <NavigationItem enabled to="/" icon="public">News Feed</NavigationItem>
+          <NavigationItem enabled icon="public" to="/">News Feed</NavigationItem>
           {currentUser}
           {likesSection}
           {favouritesSection}

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -15,7 +15,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { values, throttle } from 'lodash';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
@@ -32,6 +32,14 @@ import createSelector from '../selectors/createSelector';
 
 class Sidebar extends React.Component {
   static displayName = 'Sidebar';
+
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired
+  };
+
+  static contextTypes = {
+    routeLocation: PropTypes.shape({})
+  };
 
   constructor(props) {
     super(props);
@@ -85,10 +93,10 @@ class Sidebar extends React.Component {
   }, 100);
 
   render() {
+    const { routeLocation } = this.context;
     const {
       ui,
-      is_logged_in,
-      routing
+      is_logged_in
     } = this.props;
     const sidebarClassName = ['sidebar'];
 
@@ -174,7 +182,7 @@ class Sidebar extends React.Component {
     const test = RegExp(`user\/${username}\/?$`);
     let currentUser;
 
-    if (routing && routing.locationBeforeTransitions.pathname.match(test)) {
+    if (routeLocation && routeLocation.pathname.match(test)) {
       currentUser = (
         <NavigationItem className="sidebar__user" enabled to={`/user/${username}`}>
           <CurrentUser isLink={false} user={current_user.user} />
@@ -207,11 +215,9 @@ class Sidebar extends React.Component {
 const selector = createSelector(
   state => state.get('ui'),
   currentUserSelector,
-  state => state.get('routing'),
-  (ui, current_user, routing) => ({
+  (ui, current_user) => ({
     ui,
-    ...current_user,
-    routing
+    ...current_user
   })
 );
 

--- a/src/components/tag-like-post.js
+++ b/src/components/tag-like-post.js
@@ -66,7 +66,7 @@ const TagLikePost = ({ author, post }) => {
           was liked by
         </div>
         <div className="layout__grid_item">
-          <User avatarSize="32" user={author} />
+          <User avatar={{ size: 32 }} user={author} />
         </div>
         <div className="layout__grid_item layout__grid_item-wide"></div>
         <div className="layout__grid_item">

--- a/src/components/user-grid.js
+++ b/src/components/user-grid.js
@@ -33,7 +33,7 @@ const UserGrid = ({ current_user, i_am_following, notFoundMessage, triggers, use
     <div className="layout__grids_item layout__grids_item-space layout__grid_item-50" key={`user-${user.id}`}>
       <div className="layout__row layout__row-small">
         <User
-          avatarSize="32"
+          avatar={{ size: 32 }}
           user={user}
         />
       </div>

--- a/src/components/user/avatar-editor.js
+++ b/src/components/user/avatar-editor.js
@@ -1,0 +1,76 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import React, { PropTypes } from 'react';
+
+import { AVATAR_SIZE } from '../../consts/profileConstants';
+import UpdatePicture from '../update-picture/update-picture';
+
+export default class AvatarEditor extends React.Component {
+  static displayName = 'AvatarEditor';
+
+  static propTypes = {
+    flexible: PropTypes.bool,
+    limits: PropTypes.shape({}),
+    onUpdateAvatar: PropTypes.func,
+    preview: PropTypes.shape({}),
+    user: PropTypes.shape({
+      username: PropTypes.string
+    }).isRequired
+  };
+
+  static defaultProps = {
+    flexible: false,
+    limits: {
+      min: AVATAR_SIZE
+    },
+    preview: AVATAR_SIZE,
+    onUpdateAvatar: () => {}
+  };
+
+  render() {
+    const {
+      user,
+      flexible,
+      limits,
+      preview,
+      onUpdateAvatar
+    } = this.props;
+
+    let modalName = <span className="font-bold">{user.username}</span>;
+
+    if (user.more) {
+      if (user.more.firstName || user.more.lastName) {
+        modalName = [
+          <span className="font-bold" key="avatarEditorName">{user.more.firstName} {user.more.lastName}</span>,
+          ` (${user.username})`
+        ];
+      }
+    }
+
+    return (
+      <UpdatePicture
+        flexible={flexible}
+        limits={limits}
+        preview={preview}
+        what="profile picture"
+        where={modalName}
+        onSubmit={onUpdateAvatar}
+      />
+    );
+  }
+}

--- a/src/components/user/avatar.js
+++ b/src/components/user/avatar.js
@@ -1,0 +1,97 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+import Gravatar from 'react-gravatar';
+
+export default class Avatar extends React.Component {
+  static displayName = 'Avatar';
+
+  static propTypes = {
+    className: PropTypes.string,
+    isLink: PropTypes.bool,
+    isRound: PropTypes.bool,
+    size: PropTypes.number,
+    url: PropTypes.string,
+    user: PropTypes.shape({}),
+    userUrl: PropTypes.string
+  };
+
+  static defaultProps = {
+    isLink: false,
+    isRound: true,
+    size: 24
+  };
+
+  getImgUrl(url) {
+    const { user } = this.props;
+
+    let imgUrl;
+    if (url) {
+      imgUrl = url;
+    } else if (user.more && user.more.avatar) {
+      imgUrl = user.more.avatar.url;
+    }
+
+    return imgUrl;
+  }
+
+  render() {
+    const {
+      className,
+      isLink,
+      isRound,
+      size,
+      url,
+      user,
+      userUrl
+    } = this.props;
+
+    let finalSize = parseInt(size, 10);
+    let finalUrl = this.getImgUrl(url);
+
+    let avatar;
+    if (finalUrl) {
+      avatar = <img height={finalSize} src={finalUrl} width={finalSize}/>;
+    } else {
+      avatar = <Gravatar default="retro" md5={user.gravatarHash} size={finalSize}/>;
+    }
+
+    let cn = 'user_box__avatar';
+    if (isRound) {
+      cn += ' user_box__avatar-round';
+    }
+    if (className) {
+      cn += ` ${className}`;
+    }
+
+    if (isLink) {
+      return (
+        <Link className={cn} to={userUrl}>
+          {avatar}
+        </Link>
+      );
+    }
+
+    return (
+      <div className={cn}>
+        {avatar}
+      </div>
+    );
+  }
+}

--- a/src/components/user/index.js
+++ b/src/components/user/index.js
@@ -19,7 +19,6 @@ import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import Gravatar from 'react-gravatar';
 
-import Time from '../time';
 import { URL_NAMES, getUrl } from '../../utils/urlGenerator';
 import { AVATAR_SIZE } from '../../consts/profileConstants';
 import UpdatePicture from '../update-picture/update-picture';
@@ -33,8 +32,6 @@ const User = (props) => {
     hideText,
     isRound,
     avatarSize,
-    timestamp,
-    timestampLink,
     className,
     isLink
   } = props;
@@ -54,21 +51,21 @@ const User = (props) => {
     let avatar;
     if (avatarPreview) {
       avatar = (
-        <img src={avatarPreview.url} height={parseInt(avatarSize, 10)} width={parseInt(avatarSize, 10)} />
+        <img height={parseInt(avatarSize, 10)} src={avatarPreview.url} width={parseInt(avatarSize, 10)} />
       );
     } else if (user.more && user.more.avatar) {
       avatar = (
-        <img src={user.more.avatar.url} height={parseInt(avatarSize, 10)} width={parseInt(avatarSize, 10)} />
+        <img height={parseInt(avatarSize, 10)} src={user.more.avatar.url} width={parseInt(avatarSize, 10)} />
       );
     } else {
       avatar = (
-        <Gravatar md5={user.gravatarHash} size={parseInt(avatarSize, 10)} default="retro" />
+        <Gravatar default="retro" md5={user.gravatarHash} size={parseInt(avatarSize, 10)} />
       );
     }
 
     if (isLink) {
       render.avatar = (
-        <Link to={user_url} className={avatarClassName}>
+        <Link className={avatarClassName} to={user_url}>
           {avatar}
         </Link>
       );
@@ -87,7 +84,7 @@ const User = (props) => {
     if (user.more) {
       if (user.more.firstName || user.more.lastName) {
         modalName = [
-          <span className="font-bold">{user.more.firstName} {user.more.lastName}</span>,
+          <span className="font-bold" key="name">{user.more.firstName} {user.more.lastName}</span>,
           ` (${user.username})`
         ];
       }
@@ -95,11 +92,11 @@ const User = (props) => {
 
     render.changeAvatar = (
       <UpdatePicture
-        what="profile picture"
-        where={modalName}
+        flexible={editorConfig.flexible}
         limits={{ min: AVATAR_SIZE }}
         preview={AVATAR_SIZE}
-        flexible={editorConfig.flexible}
+        what="profile picture"
+        where={modalName}
         onSubmit={editorConfig.onUpdateAvatar}
       />
     );
@@ -119,27 +116,11 @@ const User = (props) => {
       render.name = name;
     }
 
-    let time;
-    if (timestamp.length > 0) {
-      time = <Time timestamp={timestamp} />;
-
-      if (isLink && timestampLink.length > 0) {
-        time = <Link to={timestampLink}>{time}</Link>;
-      }
-
-      render.timestamp = (
-        <p className="user_box__text">
-          {time}
-        </p>
-      );
-    }
-
     render.text = (
       <div className="user_box__body">
         <p className="user_box__name">
           {render.name}
         </p>
-        {render.timestamp}
       </div>
     );
   }
@@ -163,8 +144,6 @@ User.propTypes = {
   hideAvatar: PropTypes.bool,
   hideText: PropTypes.bool,
   isRound: PropTypes.bool,
-  timestamp: PropTypes.string,
-  timestampLink: PropTypes.string,
   user: PropTypes.shape({
     id: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
@@ -177,8 +156,6 @@ User.defaultProps = {
   hideText: false,
   isRound: true,
   avatarSize: 24,
-  timestamp: '',
-  timestampLink: '',
   isLink: true
 };
 

--- a/src/components/user/index.js
+++ b/src/components/user/index.js
@@ -14,15 +14,15 @@
 
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import Gravatar from 'react-gravatar';
 
-import Time from './time';
-import { URL_NAMES, getUrl } from '../utils/urlGenerator';
-import { AVATAR_SIZE } from '../consts/profileConstants';
-import UpdatePicture from './update-picture/update-picture';
+import Time from '../time';
+import { URL_NAMES, getUrl } from '../../utils/urlGenerator';
+import { AVATAR_SIZE } from '../../consts/profileConstants';
+import UpdatePicture from '../update-picture/update-picture';
 
 const User = (props) => {
   const {

--- a/src/components/user/index.js
+++ b/src/components/user/index.js
@@ -17,118 +17,69 @@
 */
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
-import Gravatar from 'react-gravatar';
+
+import Avatar from './avatar';
+import AvatarEditor from './avatar-editor';
+import UserText from './user-text';
 
 import { URL_NAMES, getUrl } from '../../utils/urlGenerator';
-import { AVATAR_SIZE } from '../../consts/profileConstants';
-import UpdatePicture from '../update-picture/update-picture';
 
 const User = (props) => {
   const {
-    user,
-    avatarPreview,
-    hideAvatar,
-    editorConfig,
-    hideText,
-    isRound,
-    avatarSize,
+    avatar,
+    avatarEditor,
     className,
-    isLink
+    text,
+    isLink,
+    user
   } = props;
 
+  const userUrl = getUrl(URL_NAMES.USER, { username: user.username });
   const render = {};
-  render.className = `user_box ${className || ''}`;
 
-  const user_url = getUrl(URL_NAMES.USER, { username: user.username });
-
-  if (!hideAvatar) {
-    let avatarClassName = 'user_box__avatar';
-
-    if (isRound) {
-      avatarClassName += ' user_box__avatar-round';
-    }
-
-    let avatar;
-    if (avatarPreview) {
-      avatar = (
-        <img height={parseInt(avatarSize, 10)} src={avatarPreview.url} width={parseInt(avatarSize, 10)} />
-      );
-    } else if (user.more && user.more.avatar) {
-      avatar = (
-        <img height={parseInt(avatarSize, 10)} src={user.more.avatar.url} width={parseInt(avatarSize, 10)} />
-      );
-    } else {
-      avatar = (
-        <Gravatar default="retro" md5={user.gravatarHash} size={parseInt(avatarSize, 10)} />
-      );
-    }
-
-    if (isLink) {
-      render.avatar = (
-        <Link className={avatarClassName} to={user_url}>
-          {avatar}
-        </Link>
-      );
-    } else {
-      render.avatar = (
-        <div className={avatarClassName}>
-          {avatar}
-        </div>
-      );
-    }
+  render.className = 'user_box';
+  if (className) {
+    render.className += ` ${className}`;
   }
 
-  if (editorConfig) {
-    let modalName = <span className="font-bold">{user.username}</span>;
+  if (!avatar.hide) {
+    let needLink;
 
-    if (user.more) {
-      if (user.more.firstName || user.more.lastName) {
-        modalName = [
-          <span className="font-bold" key="name">{user.more.firstName} {user.more.lastName}</span>,
-          ` (${user.username})`
-        ];
-      }
+    if (!isLink && avatar.isLink) {
+      needLink = true;
     }
 
-    render.changeAvatar = (
-      <UpdatePicture
-        flexible={editorConfig.flexible}
-        limits={{ min: AVATAR_SIZE }}
-        preview={AVATAR_SIZE}
-        what="profile picture"
-        where={modalName}
-        onSubmit={editorConfig.onUpdateAvatar}
-      />
-    );
+    render.avatar = <Avatar {...avatar} isLink={needLink} user={user} userUrl={userUrl} />;
   }
 
-  if (!hideText) {
-    let name = user.username;
+  if (avatarEditor) {
+    render.avatarEditor = <AvatarEditor user={user} {...avatarEditor} />;
+  }
 
-    if (user.more && user.more.firstName && user.more.lastName) {
-      name = `${user.more.firstName} ${user.more.lastName}`;
-    }
-    name = name.trim();
+  if (!text.hide) {
+    let needLink;
 
-    if (isLink) {
-      render.name = (<Link className="link" to={user_url}>{name}</Link>);
-    } else {
-      render.name = name;
+    if (!isLink && text.isLink) {
+      needLink = true;
     }
 
-    render.text = (
-      <div className="user_box__body">
-        <p className="user_box__name">
-          {render.name}
-        </p>
-      </div>
+    render.text = <UserText {...text} isLink={needLink} user={user} userUrl={userUrl} />;
+  }
+
+  if (isLink) {
+    return (
+      <Link className={render.className} to={userUrl}>
+        {render.avatar}
+        {render.avatarEditor}
+        {render.text}
+      </Link>
     );
   }
 
   return (
     <div className={render.className}>
       {render.avatar}
-      {render.changeAvatar}
+      {render.avatarEditor}
       {render.text}
     </div>
   );
@@ -137,13 +88,14 @@ const User = (props) => {
 User.displayName = 'User';
 
 User.propTypes = {
-  avatarSize: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number
-  ]).isRequired,
-  hideAvatar: PropTypes.bool,
-  hideText: PropTypes.bool,
-  isRound: PropTypes.bool,
+  avatar: PropTypes.shape({}),
+  avatarEditor: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.bool
+  ]),
+  className: PropTypes.string,
+  isLink: PropTypes.bool,
+  text: PropTypes.shape({}),
   user: PropTypes.shape({
     id: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
@@ -152,11 +104,15 @@ User.propTypes = {
 };
 
 User.defaultProps = {
-  hideAvatar: false,
-  hideText: false,
-  isRound: true,
-  avatarSize: 24,
-  isLink: true
+  avatar: {
+    hide: false,
+    isLink: false
+  },
+  isLink: true,
+  text: {
+    hide: false,
+    isLink: false
+  }
 };
 
 export default User;

--- a/src/components/user/user-text.js
+++ b/src/components/user/user-text.js
@@ -1,0 +1,67 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+
+export default class UserText extends React.Component {
+  static displayName = 'UserText';
+
+  static propTypes = {
+    isLink: PropTypes.bool,
+    user: PropTypes.shape({
+      username: PropTypes.string
+    }).isRequired,
+    userUrl: PropTypes.string
+  };
+
+  static defaultProps = {
+    isLink: false
+  };
+
+  getName = () => {
+    const { user } = this.props;
+    let name = user.username;
+
+    if (user.more && user.more.firstName && user.more.lastName) {
+      name = `${user.more.firstName} ${user.more.lastName}`;
+    }
+
+    return name.trim();
+  };
+
+  render() {
+    const {
+      isLink,
+      userUrl
+    } = this.props;
+
+    let name = this.getName();
+
+    if (isLink) {
+      name = <Link className="link" to={userUrl}>{name}</Link>;
+    }
+
+    return (
+      <div className="user_box__body">
+        <p className="user_box__name">
+          {name}
+        </p>
+      </div>
+    );
+  }
+}

--- a/src/pages/base/settings.js
+++ b/src/pages/base/settings.js
@@ -86,7 +86,12 @@ export default class BaseSettingsPage extends React.Component {
           <div className="header__breadcrumbs">
             <Breadcrumbs title={name}>
               <div className="user_box__avatar user_box__avatar-round">
-                <User user={user} avatarSize="36" isRound hideText isLink={false} />
+                <User
+                  avatar={{ size: 36, isRound: true }}
+                  isLink={false}
+                  text={{ hide: true }}
+                  user={user}
+                />
               </div>
             </Breadcrumbs>
           </div>

--- a/src/pages/base/user.js
+++ b/src/pages/base/user.js
@@ -74,10 +74,9 @@ const BaseUserPage = (props) => {
         <div className="header__breadcrumbs">
           <Breadcrumbs title={name}>
             <User
-              avatarSize="36"
-              hideText
+              avatar={{ size: 36, isRound: true }}
               isLink={false}
-              isRound
+              text={{ hide: true }}
               user={page_user}
             />
           </Breadcrumbs>

--- a/src/pages/user.js
+++ b/src/pages/user.js
@@ -1,6 +1,6 @@
 /*
  This file is a part of libertysoil.org website
- Copyright (C) 2015  Loki Education (Social Enterprise)
+ Copyright (C) 2016  Loki Education (Social Enterprise)
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as published by
@@ -14,8 +14,8 @@
 
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-import React from 'react';
+*/
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import Helmet from 'react-helmet';
@@ -34,12 +34,26 @@ import { defaultSelector } from '../selectors';
 class UserPage extends React.Component {
   static displayName = 'UserPage';
 
+  static propTypes = {
+    location: PropTypes.shape({}).isRequired
+  };
+
+  static childContextTypes = {
+    routeLocation: PropTypes.shape({}).isRequired // not jush 'location' to prevent misleading warnings
+  };
+
   static async fetchData(params, store, client) {
     const userInfo = await client.userInfo(params.username);
     const userPosts = client.userPosts(params.username);
 
     store.dispatch(addUser(userInfo));
     store.dispatch(setUserPosts(userInfo.id, await userPosts));
+  }
+
+  getChildContext() {
+    const { location } = this.props;
+
+    return { routeLocation: location };
   }
 
   render() {
@@ -59,8 +73,6 @@ class UserPage extends React.Component {
     if (false === page_user) {
       return <NotFound/>;
     }
-
-    //console.info(this.props);
 
     const user_posts = this.props.user_posts[page_user.id];
 


### PR DESCRIPTION
Main changes:
- `User` component: _moved into `components/user` directory_,
- `User` component: _separated into smaller parts_,
- `props` structure: _remade_,
- `User` use cases: _replaced old props to new ones_.

Also ([65c6963](https://github.com/Lokiedu/libertysoil-site/commit/65c6963597ae5408c1ab8da6afd3542f80903e12)): https://trello.com/c/U2Pn1q4O/483-issue-301-profile-name-from-menu-is-clickable-only-on-text-area