### PR TITLE
Fix for "Add tag" modal's hashtag suggest doesn't work

### DIFF
--- a/src/components/add-tag-modal/form/hashtag/select.js
+++ b/src/components/add-tag-modal/form/hashtag/select.js
@@ -59,7 +59,7 @@ export default class HashtagSelect extends Component {
     }
 
     const client = new ApiClient(API_HOST);
-    const response = await client.searchTags(value.trim());
+    const response = await client.searchHashtags(value.trim());
 
     this.setState({ suggestions: response.hashtags.slice(0, 5) });
   }, 300);


### PR DESCRIPTION
Trello: https://trello.com/c/PPMqm5ue/702-issue-509-add-tag-modal-s-hashtag-suggest-doesn-t-work