### PR TITLE
Fix post counters not decrementing on post destroy

### DIFF
--- a/src/api/controller.js
+++ b/src/api/controller.js
@@ -1537,6 +1537,8 @@ export default class ApiController {
         return;
       }
 
+      // reset post counters on attached tags and then destroy
+      await post_object.detachAllTags();
       post_object.destroy();
     } catch (e) {
       ctx.status = 500;

--- a/src/api/db/index.js
+++ b/src/api/db/index.js
@@ -291,6 +291,18 @@ export function initBookshelfFromKnex(knex) {
         this.attachGeotags(geotagsToAttach),
         this.detachGeotags(geotagsToDetach)
       ]);
+    },
+
+    /**
+     * Detach all attached tags from a post and decrements post counters.
+     * Call before destroing a post.
+     */
+    detachAllTags: async function () {
+      return Promise.all([
+        this.updateHashtags([]),
+        this.updateSchools([]),
+        this.updateGeotags([])
+      ]);
     }
   });
 


### PR DESCRIPTION
The better solution would be to decrement the counters in some
kind of "destroy hook". But it seems like it's impossible to
define a method that is called when a record is destroyed. There
are only ".on" and ".off" methods which are quite useless for
the purpose.

Closes #516.