### PR TITLE
Fixed displaying removed roles until full refresh the page

### DIFF
--- a/src/store/users.js
+++ b/src/store/users.js
@@ -58,6 +58,12 @@ export default function reducer(state = initialState, action) {
     case a.users.SET_CURRENT_USER: {
       state = state.mergeDeep(i.fromJS(cleanUser(action.user)));
 
+      if (action.user) {
+        if (action.user.more && action.user.more.roles) {
+          state = state.setIn([action.user.id, 'more', 'roles'], action.user.more.roles);
+        }
+      }
+
       break;
     }
 


### PR DESCRIPTION
Trello: https://trello.com/c/rAEc4ATX/739-issue-544-removed-roles-appears-again-after-saving-changes-and-navigating-through-the-website