### PR TITLE
EditPost: make top anchor to be initial scroll state

### DIFF
--- a/src/pages/post-edit.js
+++ b/src/pages/post-edit.js
@@ -80,6 +80,13 @@ class PostEditPage extends React.Component {
     return 200;
   }
 
+  componentDidMount() {
+    if (window) {
+      // make top anchor to be default
+      window.scrollTo(0, 0);
+    }
+  }
+
   _handleSubmit = () => {
     browserHistory.push(getUrl(URL_NAMES.POST, { uuid: this.props.params.uuid }));
   };


### PR DESCRIPTION
Trello: https://trello.com/c/jqpRgNDg/746-issue-551-page-is-not-properly-displayed-after-clicking-on-edit-icon