### PR TITLE
Don't allow to create the same error messages (+ changePassword() fixes)

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -19,7 +19,7 @@ import fetch from 'isomorphic-fetch';
 import FormData from 'form-data';
 import { format as format_url, parse as parse_url } from 'url';
 import { stringify } from 'querystring';
-import { merge as mergeObj } from 'lodash';
+import { extend, merge as mergeObj } from 'lodash';
 
 
 export default class ApiClient
@@ -367,7 +367,13 @@ export default class ApiClient
 
   async changePassword(old_password, new_password) {
     const response = await this.postJSON(`/api/v1/user/password`, { old_password, new_password });
-    return await response.json();
+
+    if (response.status !== 200) {
+      const e = extend(new Error(response.statusText), { response: await response.json() });
+      throw e;
+    }
+
+    return response.json();
   }
 
   async resetPassword(email) {

--- a/src/store/messages.js
+++ b/src/store/messages.js
@@ -16,6 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 import i from 'immutable';
+import { find } from 'lodash';
 import { LOCATION_CHANGE } from 'react-router-redux';
 
 import { messages } from '../actions';
@@ -33,6 +34,13 @@ function removeDuplicate(state, action) {
 }
 
 export default function reducer(state = initialState, action) {
+  if (find([messages.ADD_ERROR, messages.ADD_MESSAGE], a => a === action.type)) {
+    const index = state.findIndex(item => item.message === action.message);
+    if (index !== -1) {
+      state = state.delete(index);
+    }
+  }
+
   switch (action.type) {
     case messages.ADD_ERROR: {
       state = removeDuplicate(state, action);

--- a/src/triggers/index.js
+++ b/src/triggers/index.js
@@ -233,8 +233,8 @@ export class ActionsTrigger {
         success = true;
       }
     } catch (e) {
-      if (('body' in e.response) && ('error' in e.response.body)) {
-        this.dispatch(a.messages.addError(e.response.body.error));
+      if ('error' in e.response) {
+        this.dispatch(a.messages.addError(e.response.error));
       } else {
         this.dispatch(a.messages.addError(e.message));
       }


### PR DESCRIPTION
Trello: https://trello.com/c/YLZ2QO0V/742-issue-547-old-password-is-incorrect-message-can-be-duplicated-as-many-times-as-many-times-user-clicks-on-save-changes-button