### PR TITLE
Show tag likes on news feed

### DIFF
--- a/migrations/20160807222728_publish_tag_likes.js
+++ b/migrations/20160807222728_publish_tag_likes.js
@@ -1,0 +1,11 @@
+export async function up(knex) {
+  await knex('posts')
+    .whereIn('type', ['hashtag_like', 'school_like', 'geotag_like'])
+    .update('fully_published_at', knex.raw('"created_at"'));
+}
+
+export async function down(knex) {
+  await knex('posts')
+    .whereIn('type', ['hashtag_like', 'school_like', 'geotag_like'])
+    .update('fully_published_at', null);
+}

--- a/src/api/controller.js
+++ b/src/api/controller.js
@@ -2574,6 +2574,7 @@ export default class ApiController {
 
       await new Post({
         id: uuid.v4(),
+        fully_published_at: new Date().toJSON(),
         type: 'hashtag_like',
         liked_hashtag_id: hashtag.id,
         user_id: user.id
@@ -2637,6 +2638,7 @@ export default class ApiController {
 
       await new Post({
         id: uuid.v4(),
+        fully_published_at: new Date().toJSON(),
         type: 'school_like',
         liked_school_id: school.id,
         user_id: user.id
@@ -2700,6 +2702,7 @@ export default class ApiController {
 
       await new Post({
         id: uuid.v4(),
+        fully_published_at: new Date().toJSON(),
         type: 'geotag_like',
         liked_geotag_id: geotag.id,
         user_id: user.id


### PR DESCRIPTION
Apply the migration in order to show older likes.

Fixes #339.