### PR TITLE
Broke react-immutable-proptypes dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4802,11 +4802,6 @@
       "from": "react-icons@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-2.2.1.tgz"
     },
-    "react-immutable-proptypes": {
-      "version": "2.1.0",
-      "from": "react-immutable-proptypes@>=2.1.0 <2.2.0",
-      "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz"
-    },
     "react-inform": {
       "version": "0.1.2",
       "from": "react-inform@>=0.1.2 <0.2.0",
@@ -5376,14 +5371,7 @@
     "sphinxapi": {
       "version": "1.2.1",
       "from": "sphinxapi@>=1.2.1 <1.3.0",
-      "resolved": "https://registry.npmjs.org/sphinxapi/-/sphinxapi-1.2.1.tgz",
-      "dependencies": {
-        "put": {
-          "version": "0.0.6",
-          "from": "put@latest",
-          "resolved": "https://registry.npmjs.org/put/-/put-0.0.6.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/sphinxapi/-/sphinxapi-1.2.1.tgz"
     },
     "spin.js": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "react-gravatar": "^2.2.2",
     "react-helmet": "^3.1.0",
     "react-icons": "^2.1.0",
-    "react-immutable-proptypes": "~2.1.0",
     "react-inform": "^0.1.2",
     "react-leaflet": "^0.12.0",
     "react-linkify": "0.1.1",

--- a/src/pages/tools/schools-tool.js
+++ b/src/pages/tools/schools-tool.js
@@ -17,12 +17,11 @@
 */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import Helmet from 'react-helmet';
 import { Link } from 'react-router';
 
-import { School } from '../../prop-types/schools';
-import { uuid4 } from '../../prop-types/common';
+import { uuid4, Immutable as ImmutablePropType } from '../../prop-types/common';
+import { MapOfSchools } from '../../prop-types/schools';
 import createSelector from '../../selectors/createSelector';
 import { ActionsTrigger } from '../../triggers';
 import ApiClient from '../../api/client';
@@ -32,19 +31,22 @@ import VisibilitySensor from '../../components/visibility-sensor';
 import TagIcon from '../../components/tag-icon';
 import { TAG_SCHOOL } from '../../consts/tags';
 
-
 class SchoolsToolPage extends React.Component {
   static displayName = 'SchoolsToolPage';
 
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
-    schools: ImmutablePropTypes.mapOf(School, uuid4).isRequired,
-    schools_river: ImmutablePropTypes.listOf(uuid4).isRequired,
-    ui: ImmutablePropTypes.contains({
-      progress: ImmutablePropTypes.contains({
-        loadingSchoolsRiver: PropTypes.bool
-      }).isRequired
-    })
+    schools: ImmutablePropType(MapOfSchools).isRequired,
+    schools_river: ImmutablePropType(PropTypes.arrayOf(uuid4)).isRequired,
+    ui: ImmutablePropType(
+      PropTypes.shape({
+        progress: ImmutablePropType(
+          PropTypes.shape({
+            loadingSchoolsRiver: PropTypes.bool.isRequired
+          })
+        ).isRequired
+      })
+    )
   };
 
   static async fetchData(params, store, client) {


### PR DESCRIPTION
`react-immutable-proptypes` is an alternative to `React.PropTypes` primitives and it doesn't provide an opportunity to use custom validators. Furthermore, it sometimes checks input data incorrectly (see `SchoolToolsPage`).

Use `Immutable` from `prop-types/common` instead.