### PR TITLE
Fix geotags autosuggest having too many irrelevant suggestions

### DIFF
--- a/bin/geotags.js
+++ b/bin/geotags.js
@@ -280,9 +280,24 @@ async function geotags() {
   await searchIndex();
 }
 
-geotags()
+function main() {
+  const commands = {
+    planets,
+    continents,
+    countries,
+    adminDivisions,
+    cities,
+    searchIndex
+  };
+
+  const command = commands[process.argv[2]] || geotags;
+
+  return command();
+}
+
+main()
   .then(() => {
-    process.stdout.write("=== GEOTAGS DONE ===\n");
+    process.stdout.write("=== DONE ===\n");
     process.exit(0);
   })
   .catch(e => {

--- a/bin/geotags.js
+++ b/bin/geotags.js
@@ -236,6 +236,30 @@ async function cities() {
   });
 }
 
+async function searchIndex() {
+  /*
+    Weights:
+      A (primary name) = 0.4 gives some room for specifiers (country name, codes etc.)
+      B (name specifiers) = 0.8
+      C (code specifiers) = 1.0 max priority to override the name
+  */
+  await knex.raw(`
+    UPDATE geotags
+    SET tsv =
+      setweight(to_tsvector(coalesce(geotags.name, '')), 'A') ||
+      setweight(to_tsvector(coalesce(countries.iso_alpha2, '')), 'C') ||
+      setweight(to_tsvector(coalesce(countries.iso_alpha3, '')), 'C') ||
+      setweight(to_tsvector(coalesce(countries.name, '')), 'B') ||
+      setweight(to_tsvector(coalesce(admin1.name, '')), 'B') ||
+      setweight(to_tsvector(coalesce(admin1.code, '')), 'C') ||
+      setweight(to_tsvector(coalesce(geotags.type, '')), 'C')
+    FROM geotags as g2
+      LEFT JOIN geonames_countries AS countries ON countries.id = g2.geonames_country_id
+      LEFT JOIN geonames_admin1 AS admin1 ON admin1.id = g2.geonames_admin1_id
+      WHERE g2.id = geotags.id
+  `);
+}
+
 async function geotags() {
   process.stdout.write("=== IMPORTING/UPDATING PLANET GEOTAGS ===\n");
   await planets();
@@ -251,6 +275,9 @@ async function geotags() {
 
   process.stdout.write("=== IMPORTING/UPDATING CITY GEOTAGS ===\n");
   await cities();
+
+  process.stdout.write("=== UPDATING SEARCH INDEX FOR GEOTAGS ===\n");
+  await searchIndex();
 }
 
 geotags()

--- a/migrations/20160907210103_geotags_full_text_search.js
+++ b/migrations/20160907210103_geotags_full_text_search.js
@@ -1,0 +1,8 @@
+export async function up(knex) {
+  await knex.raw('ALTER TABLE geotags ADD COLUMN tsv tsvector');
+  await knex.raw('CREATE INDEX geotags_tsv_idx ON geotags USING gin(tsv)');
+}
+
+export async function down(knex) {
+  await knex.raw('ALTER TABLE geotags DROP COLUMN tsv');
+}

--- a/src/components/add-tag-modal/form/geotag/select.js
+++ b/src/components/add-tag-modal/form/geotag/select.js
@@ -72,22 +72,26 @@ export default class GeotagSelect extends Component {
   _getSuggestionValue = (geotag) => geotag.name;
 
   _renderSuggestion(geotag) {
-    let name = geotag.name;
-    const additionalInfo = [];
+    let geotagType = geotag.type;
+    if (geotagType == 'AdminDivision1') {
+      geotagType = 'Admin. Division';
+    }
+
+    const names = [geotag.name];
 
     if (!isEmpty(geotag.admin1)) {
-      additionalInfo.push(geotag.admin1.name);
+      if (geotag.country_code == 'US') {
+        names.push(geotag.admin1_code);
+      } else {
+        names.push(geotag.admin1.name);
+      }
     }
 
     if (!isEmpty(geotag.country)) {
-      additionalInfo.push(geotag.country.name);
+      names.push(geotag.country.name);
     }
 
-    if (additionalInfo.length > 0) {
-      name += ` (${additionalInfo.join(', ')})`;
-    }
-
-    return name;
+    return `${names.join(', ')} (${geotagType})`;
   }
 
   _handleSelect = (event, { suggestion }) => {

--- a/src/components/add-tag-modal/form/geotag/select.js
+++ b/src/components/add-tag-modal/form/geotag/select.js
@@ -66,7 +66,7 @@ export default class GeotagSelect extends Component {
     const client = new ApiClient(API_HOST);
     const response = await client.searchGeotags(value.trim());
 
-    this.setState({ suggestions: response.geotags.slice(0, 5) });
+    this.setState({ suggestions: response.geotags });
   }, 300);
 
   _getSuggestionValue = (geotag) => geotag.name;
@@ -114,6 +114,10 @@ export default class GeotagSelect extends Component {
       value: this.state.value
     };
 
+    const theme = {
+      suggestionsContainer: 'autosuggest__suggestions_container autosuggest__suggestions_container-with-scroll'
+    };
+
     return (
       <div>
         <input name="geotag" type="hidden" value={this.state.geotagId} />
@@ -122,6 +126,7 @@ export default class GeotagSelect extends Component {
           inputProps={inputProps}
           renderSuggestion={this._renderSuggestion}
           suggestions={this.state.suggestions}
+          theme={theme}
           onSuggestionSelected={this._handleSelect}
           onSuggestionsUpdateRequested={this._getSuggestions}
           {...this.props}

--- a/src/components/autosuggest.js
+++ b/src/components/autosuggest.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactAutosuggest from 'react-autosuggest';
+import { omit } from 'lodash';
 
 
 const theme = {
@@ -14,8 +15,15 @@ const theme = {
   sectionSuggestionsContainer: 'autosuggest__section_suggestions_container'
 };
 
-export default function Autosuggest(props) {
+function Autosuggest(props) {
+  const combinedTheme = Object.assign(theme, props.theme);
+  props = omit(props, 'theme');
+
   return (
-    <ReactAutosuggest theme={theme} {...props} />
+    <ReactAutosuggest theme={combinedTheme} {...props} />
   );
 }
+
+Autosuggest.propTypes = ReactAutosuggest.propTypes;
+
+export default Autosuggest;

--- a/src/less/blocks/autosuggest.less
+++ b/src/less/blocks/autosuggest.less
@@ -28,6 +28,11 @@
     border-bottom-left-radius: @border-radius;
     border-bottom-right-radius: @border-radius;
     z-index: 1000;
+
+    &-with-scroll {
+      max-height: 200px;
+      overflow-y: scroll;
+    }
   }
 
   &__section {


### PR DESCRIPTION
I've added a scrollbar to the geotags autosuggest dropdown and increased the limit of displayed variants to 20. I still can't see "San Francisco (California)". We need to add an additional index for geotags so we could search geotags by name + country + state + state code.
- [x] Add a scrollbar so we could display more variants without cluttering the space.
- [x] Add an index combining name, country, state, state code. We can make it in postgresql without using sphinx.

To build the index run `npm run import:geotags searchIndex`.