### PR TITLE
Migrated to webpack@2.1.0-beta.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "unexpected-react": "^3.1.1",
     "unexpected-sinon": "^10.4.0",
     "url-loader": "^0.5.7",
-    "webpack": "^2.1.0-beta.1",
+    "webpack": "^2.1.0-beta.24",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.6.0",
     "webpack-koa-hot-middleware": "^0.1.2",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -13,7 +13,7 @@ module.exports = {
   ],
 
   resolve: {
-    extensions: ['', '.js', '.jsx', '.less']
+    extensions: ['.js', '.jsx', '.less']
   },
 
   output: {
@@ -24,15 +24,14 @@ module.exports = {
   },
 
   module: {
-    postLoaders: [
+    rules: [
       // Fix grapheme-breaker
       {
+        enforce: 'post',
         test: /\.js$/,
         include: /node_modules\/grapheme-breaker/,
         loader: 'transform/cacheable?brfs'
-      }
-    ],
-    loaders: [
+      },
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,
@@ -69,13 +68,17 @@ module.exports = {
     new webpack.NoErrorsPlugin(),
     new webpack.DefinePlugin({
       __DEV__: true
+    }),
+    new webpack.LoaderOptionsPlugin({
+      debug: true,
+      options: {
+        context: __dirname,
+        postcss: [
+          autoprefixer
+        ]
+      }
     })
   ],
 
-  postcss: () => {
-    return [autoprefixer];
-  },
-
-  debug: true,
   devtool: 'cheap-module-inline-source-map'
 };

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -11,7 +11,7 @@ module.exports = {
   ],
 
   resolve: {
-    extensions: ['', '.js', '.jsx', '.less']
+    extensions: ['.js', '.jsx', '.less']
   },
 
   output: {
@@ -21,15 +21,14 @@ module.exports = {
   },
 
   module: {
-    postLoaders: [
+    rules: [
       // Fix grapheme-breaker
       {
+        enforce: 'post',
         test: /\.js$/,
         include: /node_modules\/grapheme-breaker/,
         loader: 'transform/cacheable?brfs'
-      }
-    ],
-    loaders: [
+      },
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,
@@ -62,10 +61,14 @@ module.exports = {
     new ExtractTextPlugin({
       filename: 'styles.css',
       allChunks: true
+    }),
+    new webpack.LoaderOptionsPlugin({
+      options: {
+        context: __dirname,
+        postcss: [
+          autoprefixer
+        ]
+      }
     })
-  ],
-
-  postcss: () => {
-    return [autoprefixer];
-  }
+  ]
 };


### PR DESCRIPTION
Fixed configs' errors to satisfy new webpack API schema.
Related info:
1. [webpack@v2.1.0-beta.23 changelog](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.23)
2. [webpack@v2.1.0-beta.24 changelog](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.24)
3. [The problem discussion in `postcss` issues](https://github.com/postcss/postcss-loader/issues/99)
4. [Related topic in `webpack` issues](https://github.com/webpack/webpack/issues/3018)
5. [ Webpack migration guide (from `webpack 1`)](https://github.com/webpack/webpack.js.org/blob/develop/content/how-to/upgrade-from-webpack-1.md#debug)