### PR TITLE
Test-helpers for working with eventual changes

### DIFF
--- a/test-helpers/wait.js
+++ b/test-helpers/wait.js
@@ -1,0 +1,93 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+const DEFAULT_TIMEOUT = 10000;
+
+/**
+ * Returns a promise, which is resolved if "callback" returns an error before timeout
+ * and which is rejected if there's no value in time
+ * @param callback
+ * @param timeout
+ * @returns {Promise}
+ */
+export function waitForCallback(callback, timeout = DEFAULT_TIMEOUT) {
+  let result = undefined;
+
+  const start = Date.now();
+
+  const promise = new Promise((resolve, reject) => {
+    const iteration = () => {
+      try {
+        result = callback();
+        resolve(result);
+      } catch (e) {
+        if (Date.now() - start > timeout) {
+          reject(new Error(`Callback did not succeed in ${timeout} ms`));
+          return;
+        }
+
+        setTimeout(iteration, 50);
+      }
+    };
+
+    iteration();
+  });
+
+  return promise;
+}
+
+/**
+ * Returns a promise, which is resolved as soon as "callback" returns True.
+ * and which is rejected if it doesn't do this in time
+ * @param callback
+ * @param timeout
+ * @returns {Promise}
+ */
+export function waitForTrue(callback, timeout = DEFAULT_TIMEOUT) {
+  const handler = () => {
+    const result = callback();
+
+    if (result !== true) {
+      throw new Error();
+    }
+  };
+
+  return waitForCallback(handler, timeout);
+}
+
+/**
+ * Calls "callback()", stores initial value. Returns a promise, which is resolved as soon as value returned by
+ * callback is different from the one stored, and which is rejected if it doesn't happen in time.
+ * @param callback
+ * @param timeout
+ * @returns {Promise}
+ */
+export function waitForChange(callback, timeout = DEFAULT_TIMEOUT) {
+  const initialValue = callback();
+
+  const handler = () => {
+    const newValue = callback();
+
+    if (newValue === initialValue) {
+      throw new Error();
+    }
+
+    return newValue;
+  };
+
+  return waitForCallback(handler, timeout);
+}

--- a/test/integration/pages/auth.js
+++ b/test/integration/pages/auth.js
@@ -68,9 +68,7 @@ describe('Auth page', () => {
   });
 
   describe('Register component', () => {
-    it('availableUsername should work', (done) => {
-      done();
-      return;
+    xit('availableUsername should work', (done) => {
       const testComponent = (
         <Register
           fields={{

--- a/test/integration/pages/auth.js
+++ b/test/integration/pages/auth.js
@@ -30,6 +30,7 @@ import initBookshelf from '../../../src/api/db';
 import { initState } from '../../../src/store';
 import expect from '../../../test-helpers/expect';
 import UserFactory from '../../../test-helpers/factories/user';
+import { waitForChange } from '../../../test-helpers/wait';
 
 
 const bookshelf = initBookshelf($dbConfig);
@@ -54,17 +55,16 @@ describe('Auth page', () => {
     await bookshelf.knex.raw('DELETE FROM users;');
   });
 
-  it('Login component should work', (done) => {
+  it('Login component should work', async () => {
     const testComponent = <Login onLoginUser={triggers.login} />;
     const wrapper = mount(testComponent);
+
+    const newUserId = waitForChange(() => store.getState().getIn(['current_user', 'id']));
     wrapper.find('#loginUsername').node.value = userAttrs.username;
     wrapper.find('#loginPassword').node.value = userAttrs.password;
     wrapper.find('form').simulate('submit');
 
-    setTimeout(() => {
-      expect(user.get('id'), 'to equal', store.getState().getIn(['current_user', 'id']));
-      done();
-    }, 200);
+    expect(await newUserId, 'to equal', user.get('id'));
   });
 
   describe('Register component', () => {
@@ -116,7 +116,7 @@ describe('Auth page', () => {
       await user.destroy();
     });
 
-    xit('should check on email currently taken', (done) => {
+    it('should check on email currently taken', async () => {
       const testComponent = (
         <WrappedRegister
           onRegisterUser={() => {}}
@@ -125,14 +125,12 @@ describe('Auth page', () => {
       );
       const wrapper = mount(testComponent);
 
+      const newEmailError = waitForChange(() => wrapper.state().errors.email);
+
       wrapper.find('#registerEmail').simulate('change', { target: { value: email } });
       wrapper.find('#registerForm').simulate('submit');
 
-      setTimeout(() => {
-        expect(wrapper.state().errors.email, 'to equal', 'Email is taken');
-
-        done();
-      }, 100);
+      expect(await newEmailError, 'to equal', 'Email is taken');
     });
 
     xit('Should call "registerUser" trigger with no validation error', (done) => {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --compilers js:babel-register
 --require ./test-helpers/init
 --recursive
+--timeout 20000
 --colors


### PR DESCRIPTION
* `waitForTrue(callback, timeout)` -> returns as soon as `callback()` returned `true`
* `waitForChange(callback, timeout)` -> returns as soon as `callback()` returned value different from initial
* `waitForCallback(callback, timeout)` -> returns as soon as `callback()` stops to throw exceptions

Each of these helpers will throw an Error, if condition is not fulfilled in `timeout` ms. Default timeout: `10000`

refs #673