### PR TITLE
Fix bunyan's debug logger binding to koa-webpack-dev-middleware

### DIFF
--- a/server.js
+++ b/server.js
@@ -118,7 +118,7 @@ if (exec_env === 'development') {
   const compiler = webpack(webpackConfig);
 
   app.use(convert(webpackDevMiddleware(compiler, {
-    log: logger.debug,
+    log: logger.debug.bind(logger),
     path: '/__webpack_hmr',
     publicPath: webpackConfig.output.publicPath,
     stats: {


### PR DESCRIPTION
After `npm start`:

```
bunyan usage error: /home/unexpected/work/libertysoil/node_modules/webpack-dev-
middleware/middleware.js:84: attempt to log with an unbound log method: `this` is:
{ log: [Function],
  path: '/__webpack_hmr',
  publicPath: 'http://localhost:8000/assets/',
  stats: { colors: true, context: '/home/unexpected/work/libertysoil' },
  watchOptions: { aggregateTimeout: 200 },
  reporter: [Function: defaultReporter],
  warn: [Function: bound bound ] }
```