### PR TITLE
Update edit post form using recently received props

### DIFF
--- a/src/components/edit-post.js
+++ b/src/components/edit-post.js
@@ -95,7 +95,7 @@ export default class EditPost extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (!this.state.upToDate) {
-      this.update(nextProps.post, this.props.id);
+      this.update(nextProps.post, nextProps.id);
     }
   }
 


### PR DESCRIPTION
Fix impossibility to manage tags and save not edited post after transition to `PostEditPage` from `PostPage`.