### PR TITLE
FollowTagButton: Use immutable.js Map notation of 'followed_tags'

### DIFF
--- a/src/components/follow-tag-button.js
+++ b/src/components/follow-tag-button.js
@@ -118,7 +118,7 @@ export default class FollowTagButton extends React.Component {
           return null;
       }
     } else {
-      const isFollowed = !!followed_tags[this.props.tag];
+      const isFollowed = !!followed_tags.get(this.props.tag);
 
       if (isFollowed) {
         return <button {...buttonProps} className={`button button-yellow ${className}`} type="button" onClick={this._unfollowTag}>Following</button>;


### PR DESCRIPTION
Fix the fact that `isFollowed` is always equal to `false`: [`follow-tag-button.js:121`](https://github.com/Lokiedu/libertysoil-site/blob/stable/src/components/follow-tag-button.js#L121)