### PR TITLE
Rework layout of user and tag pages

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -16,7 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 export const UI__SET_PROGRESS = 'UI__SET_PROGRESS';
-export const UI__TOGGLE_SIDEBAR = 'UI__TOGGLE_SIDEBAR';
+export const UI__TOGGLE_MENU = 'UI__TOGGLE_MENU';
 
 export const SHOW_REGISTER_FORM = 'SHOW_REGISTER_FORM';
 
@@ -28,9 +28,9 @@ export function setProgress(progress, value) {
   };
 }
 
-export function toggleSidebar(isVisible) {
+export function toggleMenu(isVisible) {
   return {
-    type: UI__TOGGLE_SIDEBAR,
+    type: UI__TOGGLE_MENU,
     isVisible
   };
 }

--- a/src/components/create-post.js
+++ b/src/components/create-post.js
@@ -244,7 +244,7 @@ class CreatePost extends React.Component {
               </div>
             </div>
             {expanded &&
-              <div className="layout__row layout layout-align_vertical">
+              <div className="layout__row layout layout-align_vertical create_post__toolbar">
                 <div className="layout__grid_item">
                   <DisabledFormSubmit
                     className="button button-wide button-red"

--- a/src/components/header-logo.js
+++ b/src/components/header-logo.js
@@ -18,11 +18,11 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 
 import { Immutable as ImmutablePropType } from '../prop-types/common';
 import { CurrentUser as CurrentUserPropType } from '../prop-types/users';
 
-import { toggleSidebar } from '../actions/ui';
 import currentUserSelector from '../selectors/currentUser';
 import createSelector from '../selectors/createSelector';
 
@@ -33,38 +33,25 @@ class HeaderLogo extends Component {
     current_user: ImmutablePropType(CurrentUserPropType)
   };
 
-  handleClick = () => {
-    const {
-      dispatch
-    } = this.props;
-
-    dispatch(toggleSidebar());
-  };
+  shouldComponentUpdate(nextProps) {
+    return nextProps !== this.props;
+  }
 
   render() {
     const {
       current_user,
       small
     } = this.props;
-    const className = ['logo'];
-    let logoBody = null;
 
-    if (small) {
-      className.push('logo-size_small');
-    }
-
-    logoBody = (
-      <div className={className.join(' ')}>
+    const logoBody = (
+      <div className={classNames('logo', { 'logo-size_small': small })}>
         <span className="logo__title">Liberty Soil</span>
       </div>
     );
 
     if (current_user.get('id')) {
       return (
-        <div
-          onClick={this.handleClick}
-          className="header__logo action"
-        >
+        <div className="header__logo action">
           {logoBody}
         </div>
       );
@@ -79,10 +66,8 @@ class HeaderLogo extends Component {
 }
 
 const selector = createSelector(
-  state => state.get('ui'),
   currentUserSelector,
-  (ui, current_user) => ({
-    ui,
+  current_user => ({
     ...current_user
   })
 );

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -22,12 +22,14 @@ import { CurrentUser as CurrentUserPropType } from '../prop-types/users';
 import AuthBlock from './auth-block';
 import HeaderLogo from './header-logo';
 import Search from './search';
+import TopMenu from './top-menu';
 
 const HeaderComponent = ({
   children,
   className,
   current_user,
   is_logged_in,
+  needMenu,
   ...props
 }) => {
   let cn = 'header page__header';
@@ -36,21 +38,26 @@ const HeaderComponent = ({
   }
 
   return (
-    <div {...props} className={cn}>
-      <div className="header__body">
-        <div className="header__content">
-          {!React.Children.count(children) &&
-            <HeaderLogo small />
-          }
-          {children}
-        </div>
-        <div className="header__toolbar">
-          <div className="header__toolbar_item header__toolbar_item-right_space">
-            <Search />
+    <div>
+      <div {...props} className={cn}>
+        <div className="header__body">
+          <div className="header__content">
+            {!React.Children.count(children) &&
+              <HeaderLogo small />
+            }
+            {children}
           </div>
-          <AuthBlock current_user={current_user} is_logged_in={is_logged_in} />
+          <div className="header__toolbar">
+            <div className="header__toolbar_item header__toolbar_item-right_space">
+              <Search />
+            </div>
+            <AuthBlock current_user={current_user} is_logged_in={is_logged_in} />
+          </div>
         </div>
       </div>
+      {needMenu &&
+        <TopMenu is_logged_in={is_logged_in} />
+      }
     </div>
   );
 };
@@ -62,6 +69,10 @@ HeaderComponent.propTypes = {
   className: PropTypes.string,
   current_user: CurrentUserPropType,
   is_logged_in: PropTypes.bool.isRequired
+};
+
+HeaderComponent.defaultProps = {
+  needMenu: true
 };
 
 export default HeaderComponent;

--- a/src/components/icon.js
+++ b/src/components/icon.js
@@ -19,9 +19,9 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 
 import * as MdIconPack from 'react-icons/lib/md';
-import { FaHashtag } from 'react-icons/lib/fa';
+import { FaHashtag, FaAt } from 'react-icons/lib/fa';
 
-const FaIconPack = { FaHashtag };
+const FaIconPack = { FaHashtag, FaAt };
 
 function findIcon(iconName) {
   const camelized = iconName.replace(/(?:^|[-_])(\w)/g, (match, c) =>

--- a/src/components/mobile-menu.js
+++ b/src/components/mobile-menu.js
@@ -1,0 +1,78 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import React from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+
+import { toggleMenu } from '../actions/ui';
+import createSelector from '../selectors/createSelector';
+import { MENU_ITEMS } from '../consts/mobile-menu';
+
+import ModalComponent from './modal-component';
+import NavigationItem from './navigation-item';
+
+class MobileMenu extends React.Component {
+  static displayName = 'MobileMenu';
+
+  shouldComponentUpdate(nextProps) {
+    return nextProps !== this.props;
+  }
+
+  render() {
+    if (!this.props.isVisible) {
+      return null;
+    }
+
+    return (
+      <div className="mobile-menu">
+        <ModalComponent
+          className="mobile-menu__container"
+          onHide={this.props.toggleMenu}
+        >
+          <div className="mobile-menu__row mobile-menu__close">
+            <div className="mobile-menu__close-button" onClick={this.props.toggleMenu} />
+          </div>
+          {MENU_ITEMS.map(item =>
+            <NavigationItem
+              className={classNames(
+                'mobile-menu__row',
+                'mobile-menu__item',
+                item.className
+              )}
+              key={item.title}
+              icon={item.icon}
+              to={item.url()}
+              theme="2.0"
+            />
+          )}
+        </ModalComponent>
+      </div>
+    );
+  }
+}
+
+const inputSelector = createSelector(
+  state => state.getIn(['ui', 'mobileMenuIsVisible']),
+  isVisible => ({ isVisible })
+);
+
+const outputSelector = dispatch => ({
+  toggleMenu: () => dispatch(toggleMenu(false))
+});
+
+export default connect(inputSelector, outputSelector)(MobileMenu);

--- a/src/components/sidebar-menu/normal.js
+++ b/src/components/sidebar-menu/normal.js
@@ -39,20 +39,17 @@ const SidebarMenuNormal = ({ current_user }) => {
 
   return (
     <Navigation>
-      {menuItemsArray.map((item, i) => (
+      {menuItemsArray.map(item =>
         <NavigationItem
           {...(item.html || {})}
           className={item.className}
           disabled={item.disabled}
           icon={item.icon}
-          key={i}
+          key={item.title}
           theme="2.0"
           to={item.url(username)}
-        >
-          {item.title.normal}
-        </NavigationItem>
-        ))
-      }
+        />
+      )}
     </Navigation>
   );
 };

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -17,7 +17,6 @@
 */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 
 import createSelector from '../selectors/createSelector';
 import currentUserSelector from '../selectors/currentUser';
@@ -27,8 +26,6 @@ import TagsInform from './tags-inform';
 
 class Sidebar extends React.Component {
   static propTypes = {
-    isFixed: PropTypes.bool,
-    isVisible: PropTypes.bool,
     theme: PropTypes.string
   };
 
@@ -37,13 +34,8 @@ class Sidebar extends React.Component {
   };
 
   getClassName = () => {
-    const className = classNames('sidebar col col-xs', {
-      'sidebar--visible': this.props.isVisible,
-      'sidebar--fixed': this.props.isFixed
-    });
-
     const finalize = s =>
-      className.concat(` col-${s} col-s-${s} col-m-${s} col-l-${s} col-xl-${s}`);
+      `sidebar col col-xs col-${s} col-s-${s} col-m-${s} col-l-${s} col-xl-${s}`;
 
     switch (this.props.theme) {
       case 'trunc': return finalize(1);
@@ -67,7 +59,7 @@ const selector = createSelector(
   currentUserSelector,
   state => state.get('ui'),
   (current_user, ui) => ({
-    isVisible: ui.get('sidebarIsVisible'),
+    isVisible: ui.get('sidebarIsVisible'), // FIXME: mobile version
     ...current_user
   })
 );

--- a/src/components/tags-inform/index.js
+++ b/src/components/tags-inform/index.js
@@ -49,19 +49,19 @@ export default class TagsInform extends React.Component {
     return {
       geotags: {
         className: 'navigation-item--color_green',
-        list: current_user.get('followed_geotags').toList(),
+        list: current_user.get('followed_geotags').toList().take(4),
         icon: { icon: 'place' },
         url: '/geo/'
       },
       hashtags: {
         className: 'navigation-item--color_blue',
-        list: current_user.get('followed_hashtags').toList(),
+        list: current_user.get('followed_hashtags').toList().take(4),
         icon: { icon: 'hashtag' },
         url: '/tag/'
       },
       schools: {
         className: 'navigation-item--color_red',
-        list: current_user.get('followed_schools').toList(),
+        list: current_user.get('followed_schools').toList().take(4),
         icon: { icon: 'school' },
         url: '/s/'
       }

--- a/src/components/tags-inform/normal.js
+++ b/src/components/tags-inform/normal.js
@@ -40,7 +40,7 @@ const TagsInformNormal = ({ tags, ...props }) => (
             theme="2.0"
           >
             <TagCloud
-              className="tags--row"
+              className="tags--row tags--queue"
               tags={ImmutableMap({ [tagTypeTitle]: tagType.list })}
               theme="min"
               truncated

--- a/src/components/top-menu.js
+++ b/src/components/top-menu.js
@@ -1,0 +1,60 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+import { connect } from 'react-redux';
+
+import { toggleMenu } from '../actions/ui';
+
+class TopMenu extends React.Component {
+  static displayName = 'TopMenu';
+  static propTypes = {
+    is_logged_in: PropTypes.boolean,
+    toggleMenu: PropTypes.func
+  };
+  static defaultProps = {
+    is_logged_in: false,
+    toggleMenu: () => {}
+  };
+
+  shouldComponentUpdate(nextProps) {
+    return nextProps.is_logged_in !== this.props.is_logged_in;
+  }
+
+  render() {
+    return (
+      <div className="top-menu layout layout-align_vertical">
+        <div className="mobile-menu__hamburger hamburger" onClick={this.props.toggleMenu}>
+          <div className="hamburger__line" />
+        </div>
+        {!this.props.is_logged_in &&
+          <div className="layout__space_left layout__space">
+            <span className="font--underlined">Welcome</span> to <span className="font--underlined">Liberty</span>!
+            Please <Link className="font--underlined clean-hover" to="/auth#register">register</Link> or <Link className="font--underlined clean-hover" to="/auth">log in</Link>.
+          </div>
+        }
+      </div>
+    );
+  }
+}
+
+const outputSelector = dispatch => ({
+  toggleMenu: () => dispatch(toggleMenu(true))
+});
+
+export default connect(null, outputSelector)(TopMenu);

--- a/src/consts/mobile-menu.js
+++ b/src/consts/mobile-menu.js
@@ -1,0 +1,51 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+export const MENU_ITEMS = [
+  {
+    className: 'mobile-menu__item--to_home',
+    icon: {
+      icon: 'public'
+    },
+    title: 'home',
+    url: () => '/'
+  },
+  {
+    className: 'mobile-menu__item--to_schools',
+    icon: {
+      icon: 'school'
+    },
+    title: 'schools',
+    url: () => '/s'
+  },
+  {
+    className: 'mobile-menu__item--to_locations',
+    icon: {
+      icon: 'location-on'
+    },
+    title: 'locations',
+    url: () => '/geo'
+  },
+  {
+    className: 'mobile-menu__item--to_people',
+    icon: {
+      icon: 'at'
+    },
+    title: 'people',
+    url: () => '/tools/people'
+  }
+];

--- a/src/consts/sidebar-menu.js
+++ b/src/consts/sidebar-menu.js
@@ -17,51 +17,39 @@
 */
 export const MENU_ITEMS = {
   news: {
-    className: 'navigation-item--color_blue',
-    title: {
-      min: 'News',
-      normal: 'News Feed'
-    },
+    className: 'navigation-item--color_blue menu__news',
     icon: {
       icon: 'public'
     },
+    title: 'news',
     url: () => '/'
   },
   likes: {
-    className: 'navigation-item--color_red',
-    title: {
-      min: 'Likes',
-      normal: 'My Likes'
-    },
+    className: 'navigation-item--color_red menu__likes',
     icon: {
       icon: 'favorite'
     },
+    title: 'likes',
     url: (username) => `/user/${username}/likes`
   },
   favourites: {
-    className: 'navigation-item--color_green',
-    title: {
-      min: 'Favs',
-      normal: 'My Favorites'
-    },
+    className: 'navigation-item--color_green menu__favs',
     icon: {
       icon: 'star'
     },
+    title: 'favs',
     url: (username) => `/user/${username}/favorites`
   },
   collections: {
-    className: 'navigation-item--color_blue navigation-item--disabled',
+    className: 'navigation-item--color_blue navigation-item--disabled menu__collect',
     disabled: true,
-    title: {
-      min: 'Collect.',
-      normal: 'Collections'
-    },
     icon: {
       icon: 'layers'
     },
     html: {
       title: 'Coming soon!'
     },
+    title: 'collect',
     url: () => '/collections'
   }
 };

--- a/src/less/blocks/box.less
+++ b/src/less/blocks/box.less
@@ -1,6 +1,5 @@
-/*
- This file is a part of libertysoil.org website
- Copyright (C) 2015  Loki Education (Social Enterprise)
+/*  This file is a part of libertysoil.org website  Copyright (C) 2015  Loki
+Education (Social Enterprise)
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as published by
@@ -29,7 +28,7 @@
 }
 
 .box-middle {
-  min-width: 320px;
+  min-width: 100px;
 }
 
 .box-space_bottom {

--- a/src/less/blocks/card.less
+++ b/src/less/blocks/card.less
@@ -55,6 +55,12 @@
 
   &__toolbars {
     &:extend(.layout);
+
+    @media (max-width: 380px) {
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+    }
   }
 }
 
@@ -123,11 +129,14 @@
 
   &-right {
     flex: none!important;
-    margin-left: @space;
 
     .card__toolbar_item {
       margin-right: 0;
       margin-left: 10px;
+
+      &:first-child {
+        margin-left: 0;
+      }
     }
   }
 

--- a/src/less/blocks/create_post.less
+++ b/src/less/blocks/create_post.less
@@ -54,4 +54,16 @@
       opacity: 1;
     }
   }
+
+  &__toolbar {
+    @media (max-width: 380px) {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
+      > *:not(:last-child) {
+        margin-bottom: 5px;
+      }
+    }
+  }
 }

--- a/src/less/blocks/mobile-menu.less
+++ b/src/less/blocks/mobile-menu.less
@@ -1,0 +1,188 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+.hamburger {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  padding: 20px 12px;
+  width: 60px;
+  height: 60px;
+  background-color: #efefef;
+  cursor: pointer;
+
+  &::before, &::after, &__line {
+    display: block;
+    flex-grow: 1;
+    height: 4px;
+    background-color: #434343;
+    border-radius: 2px;
+  }
+
+  &::before, &::after {
+    position: absolute;
+    left: 12px;
+    right: 12px;
+    content: '';
+  }
+
+  &::before {
+    top: 20px;
+  }
+
+  &::after {
+    bottom: 20px;
+  }
+
+  &__line {
+    margin: auto;
+  }
+}
+
+.mobile-menu {
+  &__hamburger {
+    display: none;
+    
+    @media @tablet-flexible {
+      display: flex;
+    }
+  }
+
+  &__container {
+    display: none;
+    overflow-y: auto;
+    background-color: rgba(67, 67, 67, 0.9);
+
+    .modal__section {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      padding: 0;
+      width: 100%;
+      max-width: 100%;
+      background: transparent;
+    }
+
+    @media @tablet-flexible {
+      display: flex;
+    }
+  }
+
+  &__row {
+    height: 60px;
+    width: 100%;
+  }
+
+
+  &__close {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: flex-start;
+
+    &-button {
+      position: relative;
+      width: 60px;
+      height: 60px;
+
+      cursor: pointer;
+
+      &::before, &::after {
+        position: absolute;
+        display: block;
+        top: calc(50% - 1px);
+        left: 10px;
+        width: 40px;
+        height: 3px;
+
+        background-color: #fff;
+        content: '';
+      }
+
+      &::before {
+        transform: rotate(45deg);
+      }
+
+      &::after {
+        transform: rotate(135deg);
+      }
+    }
+  }
+
+  &__item {
+    margin-bottom: 1px;
+    padding-left: 16px;
+    border-bottom: 1px solid #a3a3a3;
+    font-size: 16px;
+    color: #000;
+    background-color: #d9d9d9;
+
+    .navigation-item__icon {
+      position: relative;
+      flex-basis: 60px;
+      height: 59px;
+      border-left: 1px solid #a3a3a3;
+      background-color: #b7b7b7;
+      color: #b7b7b7;
+
+      svg {
+        z-index: 1;
+      }
+
+      &::before {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background-color: #d9d9d9;
+        content: '';
+        z-index: 0;
+      }
+    }
+
+    &.navigation-item--active, &:hover {
+      background-color: #d9d9d9;
+      
+      .navigation-item__content-box { 
+        background-color: inherit;
+      }
+    }
+
+    &.navigation-item--active::after {
+      content: none;
+    }
+
+    &--to_home::before {
+      content: 'Home';
+    }
+
+    &--to_schools::before {
+      content: 'All schools in the world';
+    }
+
+    &--to_locations::before {
+      content: 'Locations';
+    }
+
+    &--to_people::before {
+      content: 'People';
+    }
+  }
+}

--- a/src/less/blocks/navigation.less
+++ b/src/less/blocks/navigation.less
@@ -107,13 +107,13 @@
 
     &::after {
       position: absolute;
-      top: calc(50% - 3px);
+      top: calc(50% - 14px);
       right: -13px;
       
       display: block;
-      width: 6px;
-      height: 6px;
-      border-radius: 3px;
+      width: 4px;
+      height: 14px;
+      border-radius: 2px;
 
       content: '';
     }

--- a/src/less/blocks/page.less
+++ b/src/less/blocks/page.less
@@ -157,16 +157,6 @@
   }
 }
 
-.page-with_sidebar {
-  .page__container {
-    padding-left: @navigationWidth;
-  }
-
-  .page__container--static {
-    padding-left: 0;
-  }
-}
-
 .page__body {
   display: flex;
   flex: 1;
@@ -230,7 +220,6 @@
 .page__body_content {
   &:extend(.layout);
   &:extend(.layout-rows);
-  flex: 1;
 }
 
 .page__footer {
@@ -240,11 +229,6 @@
 .page__content {
   flex: 1;
   padding: 0 0 @doubleSpace 0;
-
-  @media @before-normal {
-    flex: none;
-    width: 100%;
-  }
 
   &-mobile_space {
     @media @before-normal {

--- a/src/less/blocks/page.less
+++ b/src/less/blocks/page.less
@@ -137,7 +137,7 @@
   background: #f3f2f1;
   order: 10;
   display: flex;
-  padding: @headerHeight 0 @space 0;
+  padding-bottom: @space;
   //transition: padding @transition__time @transition__function;
 
   @media @before-base {

--- a/src/less/blocks/page_head.less
+++ b/src/less/blocks/page_head.less
@@ -1,0 +1,45 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2015  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// A block representing a header on a page of a certain entity (user, tag, whatever).
+.page_head {
+  @size: 60px;
+
+  min-height: @size;
+  display: flex;
+  background-color: white;
+  align-items: center;
+  justify-content: space-between;
+
+  &__title {
+    display: block;
+    padding-left: @space;
+    color: @color__text;
+    font-size: 20px;
+  }
+
+  &__icon {
+    display: flex;
+    flex: 0 0 @size;
+    height: @size;
+    align-items: center;
+    justify-content: space-around;
+    //background-color: #f3f3f3; // TODO: Choose background color depending on the type of an item.
+  }
+}
+

--- a/src/less/blocks/sidebar.less
+++ b/src/less/blocks/sidebar.less
@@ -16,6 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 .sidebar {
+  .small();
   padding-right: 20px;
   overflow: hidden;
 
@@ -23,31 +24,50 @@
     padding-right: 0;
   }
 
-  @media not all and (min-width: 1140px) {
-    .sidebar-fixed();
+  @media @tablet {
+    .medium();
   }
 
-  @media @tablet-flexible {
-    width: 240px;
+  @media @narrow-desktop, @standard-desktop, @widescreen-desktop {
+    .large();
   }
 
-  &--fixed {
-    .sidebar-fixed();
+  .small() {
+    width: 60px;
+    flex-basis: auto;
+  }
+
+  .medium() {
+    width: 140px;
+    flex-basis: auto;
+
+    .menu__item(~"news", ~"Feed");
+    .menu__item(~"likes", ~"Likes");
+    .menu__item(~"favs", ~"Favs");
+    .menu__item(~"collect", ~"Collect.");
+  }
+
+  .large() {
+    width: 260px;
+
+    .menu__item(~"news", ~"News Feed");
+    .menu__item(~"likes", ~"My Likes");
+    .menu__item(~"favs", ~"My Favorites");
+    .menu__item(~"collect", ~"Collections");
+  }
+
+  .extra-large {
+    width: 360px;
+
+    .menu__item(~"news", ~"News Feed");
+    .menu__item(~"likes", ~"My Likes");  
+    .menu__item(~"favs", ~"My Favorites");
+    .menu__item(~"collect", ~"Collections"); 
   }
 }
 
-.sidebar-fixed() {
-  position: fixed;
-  left: 0;
-  bottom: 0;
-  top: @headerHeight;
-  z-index: 100;
-  transform: translateX(-110%);
-  
-  background: #fff;
-  border-right: 1px solid rgba(211, 211, 211, 0.5);
-
-  &.sidebar--visible {
-    transform: translateX(0);
+.menu__item(@key, @value) {
+  .menu__@{key} .navigation-item__content::before {
+    content: ~"'@{value}'";
   }
 }

--- a/src/less/blocks/tag.less
+++ b/src/less/blocks/tag.less
@@ -17,7 +17,8 @@
 */
 
 .tag {
-  height: 23px;
+  max-width: 135px;
+  height: 24px;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -30,14 +31,18 @@
     padding-left: 6px;
     padding-right: 10px;
     font-size: 11px;
-    line-height: 11px;
+    line-height: 20px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &__icon {
     position: relative;
-    padding: 4px;
-    width: 22px;
-    height: 22px;
+    padding: 6px;
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
     border-width: 1px;
     border-style: solid;
     border-left: none;
@@ -49,8 +54,8 @@
         &:extend(.micon);
         &:extend(.micon-small);
         
-        padding-top: 1px;
-        padding-right: 1px;
+        padding-top: 2px;
+        padding-right: 2px;
         position: absolute;
         top: 0;
         left: 0;
@@ -100,7 +105,7 @@
   }
 
   &--round {
-    border-radius: 11px;
+    border-radius: 12px;
   }
 
   .tag-type(@name, @color) {

--- a/src/less/blocks/tags.less
+++ b/src/less/blocks/tags.less
@@ -28,4 +28,31 @@
   &--row {
     flex-wrap: nowrap;
   }
+
+  &--queue {
+    width: 180px;
+
+    & > * {
+      min-width: 38px;
+      flex-basis: content;
+      flex-shrink: 200;
+      text-overflow: ellipsis;
+      overflow: hidden;
+
+      &:nth-child(1) {
+        flex-shrink: 0.1;
+      }
+      &:nth-child(2) {
+        flex-shrink: 100;
+      }
+    }
+
+    @media @tablet {
+      width: 60px;
+    }
+
+    @media @tablet-flexible {
+      display: none;
+    }
+  }
 }

--- a/src/less/blocks/top-menu.less
+++ b/src/less/blocks/top-menu.less
@@ -15,24 +15,6 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-.font {
-  &-open_sans {
-    font-family: 'Open Sans', 'Helvetica Neue', sans-serif;
-  }
-  
-  &-light {
-    font-weight: 300;
-  }
-  
-  &-bold {
-    font-weight: 800;
-  }
-
-  &--underlined {
-    text-decoration: underline;
-
-    &.clean-hover:hover {
-      text-decoration: none;
-    }
-  }
+.top-menu {
+  margin-top: 60px;
 }

--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -134,3 +134,4 @@
 @import 'blocks/form';
 @import 'blocks/sidebar';
 @import 'blocks/user_roles';
+@import 'blocks/mobile-menu';

--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -134,4 +134,5 @@
 @import 'blocks/form';
 @import 'blocks/sidebar';
 @import 'blocks/user_roles';
+@import 'blocks/top-menu';
 @import 'blocks/mobile-menu';

--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -53,6 +53,7 @@
 @import 'blocks/micon';
 
 @import 'blocks/page';
+@import 'blocks/page_head';
 @import 'blocks/header';
 @import 'blocks/logo';
 @import 'blocks/footer';

--- a/src/pages/app.js
+++ b/src/pages/app.js
@@ -20,6 +20,7 @@ import ga from 'react-google-analytics';
 import Helmet from 'react-helmet';
 
 import { ActionsTrigger } from '../triggers';
+import MobileMenu from '../components/mobile-menu';
 
 const GAInitializer = ga.Initializer;
 
@@ -61,6 +62,7 @@ export default class App extends React.Component {
         <Helmet title="" titleTemplate="%sLibertySoil.org" />
         {children}
         {gaContent}
+        <MobileMenu />
       </div>
     );
   }

--- a/src/pages/app.js
+++ b/src/pages/app.js
@@ -16,21 +16,18 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
 import ga from 'react-google-analytics';
 import Helmet from 'react-helmet';
 
-import { createSelector } from '../selectors';
 import { ActionsTrigger } from '../triggers';
 
 const GAInitializer = ga.Initializer;
 
-export class UnwrappedApp extends React.Component {
+export default class App extends React.Component {
   static displayName = 'UnwrappedApp';
 
   static propTypes = {
-    children: PropTypes.element.isRequired,
-    ui: PropTypes.shape({})
+    children: PropTypes.element.isRequired
   };
 
   static async fetchData(router, store, client) {
@@ -52,24 +49,15 @@ export class UnwrappedApp extends React.Component {
   }
 
   render() {
-    const {
-      children,
-      ui
-    } = this.props;
+    const { children } = this.props;
 
     let gaContent;
-
     if (process.env.GOOGLE_ANALYTICS_ID) {
       gaContent = <GAInitializer />;
     }
 
-    let className = 'page';
-    if (ui.get('sidebarIsVisible')) {
-      className += ' page-with_sidebar';
-    }
-
     return (
-      <div className={className}>
+      <div className="page">
         <Helmet title="" titleTemplate="%sLibertySoil.org" />
         {children}
         {gaContent}
@@ -77,11 +65,3 @@ export class UnwrappedApp extends React.Component {
     );
   }
 }
-
-const selector = createSelector(
-  state => state.get('ui'),
-  ui => ({ ui })
-);
-
-const App = connect(selector)(UnwrappedApp);
-export default App;

--- a/src/pages/auth.js
+++ b/src/pages/auth.js
@@ -104,6 +104,7 @@ export class UnwpappedAuth extends React.Component {
             is_logged_in={is_logged_in}
             current_user={current_user}
             className="header-transparent"
+            needMenu={false}
           >
             <HeaderLogo />
           </Header>

--- a/src/pages/base/settings.js
+++ b/src/pages/base/settings.js
@@ -169,10 +169,10 @@ export default class BaseSettingsPage extends React.Component {
           </div>
         </Header>
 
-        <Page className="page__container--static">
+        <Page>
           <PageMain>
             <PageBody>
-              <Sidebar isFixed={false} />
+              <Sidebar />
               <PageContent>
                 <ProfileHeader
                   current_user={current_user}

--- a/src/pages/base/tag.js
+++ b/src/pages/base/tag.js
@@ -23,7 +23,6 @@ import { ArrayOfSchools as ArrayOfSchoolsPropType } from '../../prop-types/schoo
 import {
   Page,
   PageMain,
-  PageCaption,
   PageHero,
   PageBody,
   PageContent
@@ -39,6 +38,7 @@ import Sidebar          from '../../components/sidebar';
 import SidebarAlt       from '../../components/sidebarAlt';
 import AddedTags        from '../../components/post/added-tags';
 import UpdatePicture    from '../../components/update-picture/update-picture';
+import Tag              from '../../components/tag';
 import { TAG_SCHOOL, TAG_LOCATION, TAG_HASHTAG, TAG_HEADER_SIZE, DEFAULT_HEADER_PICTURE } from '../../consts/tags';
 
 function formInitialTags(type, value) {
@@ -66,9 +66,14 @@ function getPageCaption(type, name) {
   }
 
   return (
-    <PageCaption>
-      {caption}
-    </PageCaption>
+    <div className="page_head">
+      <h1 className="page_head__title">
+        {caption}
+      </h1>
+      <div className="page_head__icon">
+        <Tag size="BIG" type={type} />
+      </div>
+    </div>
   );
 }
 
@@ -287,37 +292,34 @@ export default class BaseTagPage extends React.Component {
         </Header>
 
         <Page>
-          <Sidebar current_user={current_user} />
-          <PageMain className="page__main-no_space">
-            {pageCaption}
-            <TagPageHero
-              editable={editable}
-              flexible
-              limits={{ min: TAG_HEADER_SIZE.MIN, max: TAG_HEADER_SIZE.BIG }}
-              preview={TAG_HEADER_SIZE.PREVIEW}
-              tag={tag}
-              type={type}
-              url={headerPictureUrl}
-              onSubmit={this.addPicture}
-            />
+          <PageMain>
             <PageBody className="page__body-up">
-              <TagHeader
-                current_user={current_user}
-                editable={editable}
-                is_logged_in={is_logged_in}
-                newPost={this.toggleForm}
-                postsAmount={postsAmount}
-                tag={tag}
-                triggers={triggers}
-                type={type}
-              />
-
-            </PageBody>
-            <PageBody className="page__body-up">
+              <Sidebar current_user={current_user} />
               <PageContent>
+                {createPostForm}
+                {pageCaption}
+                <TagPageHero
+                  editable={editable}
+                  flexible
+                  limits={{ min: TAG_HEADER_SIZE.MIN, max: TAG_HEADER_SIZE.BIG }}
+                  preview={TAG_HEADER_SIZE.PREVIEW}
+                  tag={tag}
+                  type={type}
+                  url={headerPictureUrl}
+                  onSubmit={this.addPicture}
+                />
+                <TagHeader
+                  current_user={current_user}
+                  editable={editable}
+                  is_logged_in={is_logged_in}
+                  newPost={this.toggleForm}
+                  postsAmount={postsAmount}
+                  tag={tag}
+                  triggers={triggers}
+                  type={type}
+                />
                 <div className="layout__space-double" />
                 <div className="layout__row">
-                  {createPostForm}
                   {this.props.children}
                 </div>
               </PageContent>

--- a/src/pages/base/user-without_header.js
+++ b/src/pages/base/user-without_header.js
@@ -79,10 +79,10 @@ const BaseUserPageWithoutHeader = (props) => {
         </div>
       </Header>
 
-      <Page className="page__container--static">
+      <Page>
         <PageMain>
           <PageBody>
-            <Sidebar isFixed={false} />
+            <Sidebar />
             <PageContent>
               {children}
             </PageContent>

--- a/src/pages/base/user.js
+++ b/src/pages/base/user.js
@@ -102,6 +102,7 @@ const BaseUserPage = (props) => {
             user={user}
           />
           <PageBody>
+            <Sidebar />
             <PageContent>
               <div className="layout__space-double">
                 <div className="layout__grid tabs">

--- a/src/pages/base/user.js
+++ b/src/pages/base/user.js
@@ -33,6 +33,7 @@ import {
   PageBody,
   PageContent
 } from '../../components/page';
+import Avatar from '../../components/user/avatar';
 import Breadcrumbs from '../../components/breadcrumbs/breadcrumbs';
 import Header from '../../components/header';
 import HeaderLogo from '../../components/header-logo';
@@ -42,6 +43,7 @@ import ProfileHeader from '../../components/profile';
 import Sidebar from '../../components/sidebar';
 import SidebarAlt from '../../components/sidebarAlt';
 import User from '../../components/user';
+import { getName } from '../../utils/user';
 
 // FIXME: These links won't hide/show properly if following/unfollowing is performed directly on the page.
 // Something is wrong with the redux state.
@@ -91,19 +93,26 @@ const BaseUserPage = (props) => {
       </Header>
 
       <Page>
-        <Sidebar />
-        <PageMain className="page__main-no_space">
-          <ProfileHeader
-            current_user={current_user}
-            editable={false}
-            followers={followers}
-            following={following}
-            triggers={triggers}
-            user={user}
-          />
+        <PageMain>
           <PageBody>
             <Sidebar />
             <PageContent>
+              <div className="page_head">
+                <h1 className="page_head__title">
+                  {getName(user)}
+                </h1>
+                <div className="page_head__icon">
+                  <Avatar user={user} size={37} />
+                </div>
+              </div>
+              <ProfileHeader
+                current_user={current_user}
+                editable={false}
+                followers={followers}
+                following={following}
+                triggers={triggers}
+                user={user}
+              />
               <div className="layout__space-double">
                 <div className="layout__grid tabs">
                   <div className="layout__grid_item">

--- a/src/pages/list.js
+++ b/src/pages/list.js
@@ -199,10 +199,10 @@ export class UnwrappedListPage extends React.Component {
           <Breadcrumbs title="News Feed" />
         </Header>
 
-        <Page className="page__container--static">
+        <Page>
           <PageMain>
             <PageBody>
-              <Sidebar isFixed={false} />
+              <Sidebar />
               <PageContent>
                 <CreatePost
                   actions={actions}

--- a/src/pages/new-password.js
+++ b/src/pages/new-password.js
@@ -163,7 +163,7 @@ class PasswordPage extends React.Component {
     return (
       <div>
         <Helmet title="Set New Password for " />
-        <Header is_logged_in={is_logged_in} />
+        <Header is_logged_in={is_logged_in} needMenu={false} />
 
         <Page className="page__container-no_sidebar">
           <PageMain>

--- a/src/pages/not-found.js
+++ b/src/pages/not-found.js
@@ -32,34 +32,26 @@ import Header from '../components/header';
 import Sidebar from '../components/sidebar';
 
 
-const NotFound = ({ is_logged_in, current_user }) => {
-  let pageClassName = 'page__container--static';
-
-  if (!is_logged_in) {
-    pageClassName += ' page__container-no_sidebar';
-  }
-
-  return (
-    <div>
-      <Helmet title="Page not found at " />
-      <Header current_user={current_user} is_logged_in={is_logged_in} />
-      <Page className={pageClassName}>
-        <PageMain>
-          <PageBody>
-            <Sidebar isFixed={false} />
-            <PageContent>
-              <section className="box">
-                <div className="box__title">
-                  <p><strong>Page Not Found</strong></p>
-                </div>
-              </section>
-            </PageContent>
-          </PageBody>
-        </PageMain>
-      </Page>
-    </div>
-  );
-};
+const NotFound = ({ is_logged_in, current_user }) => (
+  <div>
+    <Helmet title="Page not found at " />
+    <Header current_user={current_user} is_logged_in={is_logged_in} />
+    <Page>
+      <PageMain>
+        <PageBody>
+          <Sidebar />
+          <PageContent>
+            <section className="box">
+              <div className="box__title">
+                <p><strong>Page Not Found</strong></p>
+              </div>
+            </section>
+          </PageContent>
+        </PageBody>
+      </PageMain>
+    </Page>
+  </div>
+);
 
 NotFound.displayName = 'NotFound';
 

--- a/src/pages/password-reset.js
+++ b/src/pages/password-reset.js
@@ -95,6 +95,7 @@ export class PasswordResetPage extends React.Component {
           <Header
             className="header-transparent"
             is_logged_in={is_logged_in}
+            needMenu={false}
           />
           <header className="landing__body">
             <p className="layout__row layout__row-small landing__small_title" style={{ position: 'relative', left: 4 }}>Welcome to LibertySoil.org</p>

--- a/src/pages/post.js
+++ b/src/pages/post.js
@@ -148,10 +148,10 @@ export class UnwrappedPostPage extends React.Component {
           </Breadcrumbs>
         </Header>
 
-        <Page className="page__container--static">
+        <Page>
           <PageMain>
             <PageBody>
-              <Sidebar isFixed={false} />
+              <Sidebar />
               <PageContent>
                 <PostWrapper
                   author={author}

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -48,7 +48,7 @@ class Welcome extends React.Component {
         <Helmet title="Welcome to " />
         <div className="page__container-bg font-open_sans font-light">
           <section className="landing landing-big landing-bg">
-            <Header is_logged_in={false} className="header-transparent">
+            <Header is_logged_in={false} className="header-transparent" needMenu={false}>
               <HeaderLogo big />
             </Header>
             <header className="landing__header">

--- a/src/store/ui.js
+++ b/src/store/ui.js
@@ -16,11 +16,12 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 import i from 'immutable';
+import { LOCATION_CHANGE } from 'react-router-redux';
 
 import * as a from '../actions';
 
 const initialState = i.fromJS({
-  sidebarIsVisible: true,
+  mobileMenuIsVisible: false,
   progress: {},
   comments: {
     new: {}
@@ -29,15 +30,23 @@ const initialState = i.fromJS({
 
 function reducer(state = initialState, action) {
   switch (action.type) {
-    case a.ui.UI__TOGGLE_SIDEBAR:
+    case LOCATION_CHANGE:
       {
-        let isVisible = !state.get('sidebarIsVisible');
+        if (state.get('mobileMenuIsVisible')) {
+          state = state.set('mobileMenuIsVisible', false);
+        }
+
+        break;
+      }
+    case a.ui.UI__TOGGLE_MENU:
+      {
+        let isVisible = !state.get('mobileMenuIsVisible');
 
         if (action.isVisible != undefined) {
           isVisible = action.isVisible;
         }
 
-        state = state.set('sidebarIsVisible', isVisible);
+        state = state.set('mobileMenuIsVisible', isVisible);
 
         break;
       }

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -1,0 +1,27 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2015  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export function getName(user) {
+  let name = user.get('username');
+
+  if (user.getIn(['more', 'firstName']) && user.getIn(['more', 'lastName'])) {
+    name = `${user.getIn(['more', 'firstName'])} ${user.getIn(['more', 'lastName'])}`;
+  }
+
+  return name.trim();
+}

--- a/test/unit/pages/app.js
+++ b/test/unit/pages/app.js
@@ -20,7 +20,7 @@ import ga from 'react-google-analytics';
 import i from 'immutable';
 
 import { TestUtils, unexpected, expect, React } from '../../../test-helpers/expect-unit';
-import { UnwrappedApp } from '../../../src/pages/app';
+import App from '../../../src/pages/app';
 
 
 const props = {
@@ -31,13 +31,13 @@ const props = {
 
 const GAInitializer = ga.Initializer;
 
-describe('UnwrappedApp page', function() {
+describe('App page', function() {
 
   it('SHOULD NOT render GA when process.env.GOOGLE_ANALYTICS_ID not set', function() {
     let renderer = TestUtils.createRenderer();
 
     delete process.env.GOOGLE_ANALYTICS_ID;
-    renderer.render(<UnwrappedApp {...props}><span>foo</span></UnwrappedApp>);
+    renderer.render(<App {...props}><span>foo</span></App>);
 
     return expect(renderer, 'not to contain', <GAInitializer />);
   });
@@ -46,7 +46,7 @@ describe('UnwrappedApp page', function() {
     let renderer = TestUtils.createRenderer();
 
     process.env.GOOGLE_ANALYTICS_ID = 100;
-    renderer.render(<UnwrappedApp {...props}><span>foo</span></UnwrappedApp>);
+    renderer.render(<App {...props}><span>foo</span></App>);
 
     return expect(renderer, 'to contain', <GAInitializer />);
   });


### PR DESCRIPTION
Closes #747.
Merge after #751.

- [x] Relocated the sidebar.
- [x] Added a new header.

There is some stuff to clean up:
1. What should we do with the content of hero (header) blocks?
2. Now that the left sidebar is inside the `page__body`, it doesn't interact well with the `page__content`: on lower screen resolutions they occupy separate lines. This happens due to `flex-wrap: wrap`. `nowrap` fixes the left sidebar but breaks the right one.
3. I added the new header block as a new block, but it probably should replace `page__caption` or `page__header`.