### PR TITLE
Complete Search API implementation on both sides

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -18,17 +18,21 @@
 export const SET_SEARCH_RESULTS = 'SET_SEARCH_RESULTS';
 export const CLEAR_SEARCH_RESULTS = 'CLEAR_SEARCH_RESULTS';
 
-export function setSearchResults(results) {
+export function setSearchResults(results, more) {
   return {
     type: SET_SEARCH_RESULTS,
     payload: {
-      results
+      results,
+      more
     }
   };
 }
 
-export function clearSearchResults() {
+export function clearSearchResults(searchId) {
   return {
-    type: CLEAR_SEARCH_RESULTS
+    type: CLEAR_SEARCH_RESULTS,
+    payload: {
+      searchId
+    }
   };
 }

--- a/src/api/controller.js
+++ b/src/api/controller.js
@@ -2747,6 +2747,8 @@ export default class ApiController {
 
     if (!ctx.query.sort || ctx.query.sort === '-q') {
       this.sphinx.api.SetSortMode(0); // SphinxClient.SPH_SORT_RELEVANCE
+    } else {
+      this.sphinx.api.SetSortMode(1, 'updated_at'); // SphinxClient.SPH_SORT_ATTR_DESC
     }
 
     try {

--- a/src/api/controller.js
+++ b/src/api/controller.js
@@ -2738,12 +2738,7 @@ export default class ApiController {
 
     const limit = parseInt(ctx.query.limit, 10) || 20;
     const offset = parseInt(ctx.query.offset, 10) || 0;
-
-    let total = 100;
-    if (limit > total) {
-      total = limit;
-    }
-    this.sphinx.api.SetLimits(offset, limit, total, total);
+    this.sphinx.api.SetLimits(offset, limit, offset + limit + 1000);
 
     if (!ctx.query.sort || ctx.query.sort === '-q') {
       this.sphinx.api.SetSortMode(0); // SphinxClient.SPH_SORT_RELEVANCE

--- a/src/api/controller.js
+++ b/src/api/controller.js
@@ -32,14 +32,15 @@ import { hidePostsData } from '../utils/posts';
 import { removeWhitespace } from '../utils/lang';
 import { processImage as processImageUtil } from '../utils/image';
 import config from '../../config';
+import { SEARCH_INDEXES_TABLE, SEARCH_RESPONSE_TABLE } from '../consts/search';
 import {
   User as UserValidators,
   School as SchoolValidators,
   Hashtag as HashtagValidators,
   Geotag as GeotagValidators,
-  UserMessage as UserMessageValidators
+  UserMessage as UserMessageValidators,
+  SearchQuery as SearchQueryValidators
 } from './db/validators';
-
 
 const bcryptAsync = bb.promisifyAll(bcrypt);
 const POST_RELATIONS = Object.freeze([
@@ -2709,37 +2710,75 @@ export default class ApiController {
   };
 
   search = async (ctx) => {
-    const { q } = ctx.query;
+    try {
+      await new Checkit(SearchQueryValidators).run(ctx.query);
+    } catch (e) {
+      ctx.status = 400;
+      ctx.body = { error: e.toJSON() };
+      return;
+    }
 
-    this.sphinx.api.SetMatchMode(4); //SPH_MATCH_EXTENDED
-    this.sphinx.api.SetLimits(0, 100, 100, 100);
+    const { show } = ctx.query;
+    let indexes;
+    if (typeof show === 'string') {
+      if (show === 'all') {
+        indexes = _.values(SEARCH_INDEXES_TABLE);
+      } else {
+        indexes = [SEARCH_INDEXES_TABLE[show]];
+      }
+    } else if (Array.isArray(show)) {
+      indexes = _.values(_.pickBy(SEARCH_INDEXES_TABLE, (v, k) =>
+        show.includes(k)
+      ));
+    } else {
+      indexes = _.values(SEARCH_INDEXES_TABLE);
+    }
+
+    this.sphinx.api.SetMatchMode(4); // SphinxClient.SPH_MATCH_EXTENDED
+
+    const limit = parseInt(ctx.query.limit, 10) || 20;
+    const offset = parseInt(ctx.query.offset, 10) || 0;
+
+    let total = 100;
+    if (limit > total) {
+      total = limit;
+    }
+    this.sphinx.api.SetLimits(offset, limit, total, total);
+
+    if (!ctx.query.sort || ctx.query.sort === '-q') {
+      this.sphinx.api.SetSortMode(0); // SphinxClient.SPH_SORT_RELEVANCE
+    }
 
     try {
-      const result = await this.sphinx.api.QueryAsync(`*${q}*`, 'PostsRT,UsersRT,HashtagsRT,GeotagsRT,SchoolsRT,CommentsRT');
+      for (let i = 0, l = indexes.length, q = `*${ctx.query.q}*`; i < l; ++i) {
+        this.sphinx.api.AddQuery(q, indexes[i]);
+      }
 
-      if ('matches' in result) {
-        const result_groups = _.groupBy(result.matches, 'attrs.type');
+      const results = await this.sphinx.api.RunQueriesAsync();
+      const nonEmptyResults = results.filter(group => group.total_found > 0);
 
-        const grouped_result_objects = {};
+      if (nonEmptyResults.length > 0) {
+        const processedGroups = await Promise.all(
+          nonEmptyResults.map(group => {
+            const type = group.matches[0].attrs.type,
+              Model = this.bookshelf.model(type),
+              ids   = group.matches.map(item => item.attrs.uuid);
 
-        for (const result_type in result_groups) {
-          const group_ids = _.map(result_groups[result_type], 'attrs.uuid');
+            return Model.forge()
+              .query(qb => qb.whereIn('id', ids)).fetchAll()
+              .then(items => ({
+                [SEARCH_RESPONSE_TABLE[type]]: {
+                  count: group.total_found, items
+                }
+              }));
+          }));
 
-          const ResultGroup = this.bookshelf.model(result_type);
-          const q = ResultGroup.forge()
-            .query(qb => {
-              qb.where('id', 'IN', group_ids);
-            });
-
-          grouped_result_objects[result_type] = await q.fetchAll();
-        }
-
-        ctx.body = _.transform(grouped_result_objects, (acc, value, key) => {
-          acc[key.toLowerCase().concat('s')] = { count: value.length, items: value };
-        }, {});
+        ctx.body = processedGroups.reduce(
+          (res, groupData) => Object.assign(res, groupData),
+          {}
+        );
       } else {
-        ctx.body = {};
-        return;
+        ctx.status = 404;
       }
     } catch (err) {
       ctx.app.emit('error', err);

--- a/src/api/db/validators.js
+++ b/src/api/db/validators.js
@@ -14,8 +14,11 @@
 
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-const User = {
+*/
+import difference from 'lodash/difference';
+import uniq from 'lodash/uniq';
+
+export const User = {
   registration: {
     username: [
       'required',
@@ -70,21 +73,21 @@ const User = {
   }
 };
 
-const School = {
+export const School = {
   more: {
     head_pic: ['plainObject'],
     last_editor: ['string']
   }
 };
 
-const Geotag = {
+export const Geotag = {
   more: {
     description: ['string'],
     last_editor: ['string']
   }
 };
 
-const Hashtag = {
+export const Hashtag = {
   more: {
     description: ['string'],
     head_pic: ['plainObject'],
@@ -92,11 +95,11 @@ const Hashtag = {
   }
 };
 
-const UserMessage = {
+export const UserMessage = {
   text: ['string', 'minLength:1', 'required']
 };
 
-const ProfilePost = {
+export const ProfilePost = {
   text: ['string', 'maxLength:200'],
   html: ['string'],
   type: [
@@ -117,4 +120,44 @@ ProfilePost.TYPES = [
   'avatar'
 ];
 
-export { User, School, Hashtag, Geotag, UserMessage, ProfilePost };
+const SEARCH_RESULT_TYPES = [
+  'hashtags',
+  'locations',
+  'posts',
+  'people',
+  'schools'
+];
+const SORTING_TYPES = [
+  '-q',
+  '-updated_at'
+];
+export const SearchQuery = {
+  limit: ['integer', 'natural'],
+  offset: ['integer', 'natural'],
+  show: {
+    rule: val => {
+      if (val) {
+        if (typeof val === 'string') {
+          if (val !== 'all' && !SEARCH_RESULT_TYPES.includes(val)) {
+            throw new Error('Unsupported type of search result');
+          }
+        } else if (Array.isArray(val)) {
+          const unique = uniq(val);
+          if (unique.length > 1 && unique.includes('all')) {
+            throw new Error('Ambiguity between "all" and explicit type of search results');
+          } else if (difference(unique, SEARCH_RESULT_TYPES).length > 0) {
+            throw new Error('At least one of presented search result types is unsupported');
+          }
+        } else {
+          throw new Error('Type of search results is expected to be a string or an array');
+        }
+      }
+    }
+  },
+  sort: ['string', val => {
+    if (val && !SORTING_TYPES.includes(val)) {
+      throw new Error('Invalid search sorting type');
+    }
+  }],
+  q: ['string']
+};

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -28,6 +28,7 @@ import ApiClient from '../api/client';
 import { API_HOST } from '../config';
 import { ActionsTrigger } from '../triggers';
 import createSelector from '../selectors/createSelector';
+import { searchObject } from '../store/search';
 
 import { TAG_HASHTAG, TAG_SCHOOL, TAG_LOCATION, TAG_PLANET } from '../consts/tags';
 import { clearSearchResults } from '../actions/search';
@@ -58,6 +59,9 @@ class Search extends Component {
       loading: false,
       query: ''
     };
+
+    const client = new ApiClient(API_HOST);
+    this.triggers = new ActionsTrigger(client, props.dispatch);
   }
 
   onClickOutside = () => {
@@ -70,10 +74,7 @@ class Search extends Component {
     if (q) {
       this.setState({ loading: true });
 
-      const client = new ApiClient(API_HOST);
-      const triggers = new ActionsTrigger(client, this.props.dispatch);
-
-      triggers.search({ q })
+      this.triggers.search({ q }, { searchId: 'header' })
         .then(() => {
           this.setState({ loading: false });
         })
@@ -271,10 +272,8 @@ class Search extends Component {
 }
 
 const selector = createSelector(
-  state => state.get('search'),
-  search => ({
-    results: search.get('results').toJS()
-  })
+  (state) => state.getIn(['search', 'header'], searchObject).get('results'),
+  results => ({ results: results.toJS() })
 );
 
 const DecoratedSearch = ClickOutsideComponentDecorator(Search);

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -64,20 +64,16 @@ class Search extends Component {
     this.toggle(false);
   };
 
-  callSearchAPI = debounce((query) => {
-    let searchQuery = query;
+  callSearchAPI = debounce((query = '') => {
+    const q = query.trim();
 
-    if (searchQuery) {
-      searchQuery = searchQuery.trim();
-    }
-
-    if (searchQuery) {
+    if (q) {
       this.setState({ loading: true });
 
       const client = new ApiClient(API_HOST);
       const triggers = new ActionsTrigger(client, this.props.dispatch);
 
-      triggers.search({ q: searchQuery })
+      triggers.search({ q })
         .then(() => {
           this.setState({ loading: false });
         })
@@ -173,7 +169,7 @@ class Search extends Component {
           let icon, name, url;
 
           switch (tag.tagType) {
-            case 'geotags': {
+            case 'locations': {
               icon = <TagIcon big type={TAG_LOCATION} />;
               name = tag.name;
               url = `/geo/${tag.url_name}`;

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -135,6 +135,7 @@ class Search extends Component {
 
   onKeyDown = (e) => {
     if (e.keyCode === 13) {
+      this.toggle(false);
       browserHistory.push({
         pathname: '/search',
         query: { q: this.state.query }

--- a/src/components/search/page-bar.js
+++ b/src/components/search/page-bar.js
@@ -19,9 +19,26 @@ import React from 'react';
 import { Link } from 'react-router';
 
 export default class SearchPageBar extends React.Component {
-  shouldComponentUpdate(nextProps) {
-    return nextProps !== this.props;
+  constructor(props, ...args) {
+    super(props, ...args);
+    this.state = { q: props.location.query.q || '' };
   }
+
+  componentWillReceiveProps(nextProps) {
+    const nextQ = nextProps.location.query.q;
+    if (nextQ !== this.props.location.query.q) {
+      this.setState({ q: nextQ });
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return nextProps !== this.props
+      || nextState.q !== this.state.q;
+  }
+
+  handleChange = (e) => {
+    this.setState({ q: e.target.value });
+  };
 
   handleFormSubmit = event => {
     event.preventDefault();
@@ -32,11 +49,11 @@ export default class SearchPageBar extends React.Component {
 
   // also fires just after location change
   submitQuery = location => {
-    if (!this.searchBar) {
+    const q = this.state.q;
+    if (!q) {
       return location;
     }
 
-    const q = this.searchBar.value;
     const query = { ...location.query, q };
     return { ...location, query };
   };
@@ -46,11 +63,11 @@ export default class SearchPageBar extends React.Component {
       <form className="layout list_item search__page-bar" onSubmit={this.handleFormSubmit}>
         <input
           className="input input-transparent search__page-input layout__grid_item layout__grid_item-fill layout__grid_item-wide"
-          defaultValue={this.props.location.query.q}
           name="q"
           placeholder="Search"
-          ref={c => this.searchBar = c}
           type="text"
+          value={this.state.q}
+          onChange={this.handleChange}
         />
         <Link
           className="button button-light_blue search__button"

--- a/src/components/search/section.js
+++ b/src/components/search/section.js
@@ -105,15 +105,11 @@ export default class SearchSection extends React.Component {
       return null;
     }
 
-    console.log(type);
-
     let itemsToRender;
     if (needPaging) {
-      itemsToRender = items
-        .slice(offset, offset + SEARCH_RESULTS_PER_PAGE);
+      itemsToRender = items;
     } else {
-      itemsToRender = items
-        .slice(offset, offset + SEARCH_RESULTS_PER_PAGE / 2);
+      itemsToRender = items.take(SEARCH_RESULTS_PER_PAGE / 2);
     }
 
     const rendered = this.renderItems(type, itemsToRender, props);

--- a/src/components/search/section.js
+++ b/src/components/search/section.js
@@ -52,7 +52,7 @@ export default class SearchSection extends React.Component {
           />
         );
       }
-      case 'geotags':
+      case 'locations':
       case 'hashtags':
       case 'schools': {
         const model = ImmutableMap({ [type]: items });
@@ -104,6 +104,8 @@ export default class SearchSection extends React.Component {
     if (!items.size) {
       return null;
     }
+
+    console.log(type);
 
     let itemsToRender;
     if (needPaging) {

--- a/src/consts/search.js
+++ b/src/consts/search.js
@@ -44,3 +44,21 @@ export const SEARCH_SECTIONS_COUNTABILITY = {
   posts: ['post', 'posts'],
   schools: ['school', 'schools']
 };
+
+export const SEARCH_INDEXES_TABLE = {
+  comments: 'CommentsRT',
+  hashtags: 'HashtagsRT',
+  locations: 'GeotagsRT',
+  people: 'UsersRT',
+  posts: 'PostsRT',
+  schools: 'SchoolsRT'
+};
+
+export const SEARCH_RESPONSE_TABLE = {
+  Comment: 'comments',
+  Hashtag: 'hashtags',
+  Geotag: 'locations',
+  User: 'people',
+  Post: 'posts',
+  School: 'schools'
+};

--- a/src/definitions/search.js
+++ b/src/definitions/search.js
@@ -29,7 +29,7 @@ export type SearchResult<T> = {
 };
 
 export type SearchResponse = {
-  geotags?: SearchResult<Geotag>,
+  locations?: SearchResult<Geotag>,
   hashtags?: SearchResult<Hashtag>,
   posts?: SearchResult<Post>,
   schools?: SearchResult<School>,

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -50,7 +50,7 @@ import SearchPageBar from '../components/search/page-bar';
 import SortingFilter from '../components/filters/sorting-filter';
 
 function filterSections(query = {}) {
-  const visible = ['geotags', 'hashtags', 'schools', 'posts', 'people'];
+  const visible = ['locations', 'hashtags', 'schools', 'posts', 'people'];
   if (!query.show || query.show === 'all') {
     return visible;
   }
@@ -58,11 +58,6 @@ function filterSections(query = {}) {
   let queried = clone(query.show);
   if (!Array.isArray(queried)) {
     queried = [queried];
-  }
-
-  const index = queried.indexOf('locations');
-  if (index >= 0) {
-    queried[index] = 'geotags';
   }
 
   return intersection(visible, queried);
@@ -88,9 +83,9 @@ class SearchPage extends Component {
     await triggers.search(query);
   }
 
-  constructor(...props) {
-    super(...props);
-    this.triggers = new ActionsTrigger(client, this.props.dispatch);
+  constructor(props, ...args) {
+    super(props, ...args);
+    this.triggers = new ActionsTrigger(client, props.dispatch);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -29,6 +29,7 @@ import { API_HOST } from '../config';
 import { CurrentUser as CurrentUserPropType } from '../prop-types/users';
 import { SEARCH_SORTING_TYPES } from '../consts/search';
 import { offsetTop } from '../utils/browser';
+import { searchObject } from '../store/search';
 
 import {
   Page,
@@ -80,7 +81,7 @@ class SearchPage extends Component {
     if (router.type) {
       query.show = router.type;
     }
-    await triggers.search(query);
+    await triggers.search(query, { searchId: 'page' });
   }
 
   constructor(props, ...args) {
@@ -95,7 +96,7 @@ class SearchPage extends Component {
     }
 
     if (!isEqual(this.props.location.query, nextQuery)) {
-      this.triggers.search(nextQuery);
+      this.triggers.search(nextQuery, { searchId: 'page' });
     }
   }
 
@@ -192,7 +193,7 @@ class SearchPage extends Component {
 }
 
 const selector = createSelector(
-  [currentUserSelector, state => state.get('search')],
+  [currentUserSelector, state => state.getIn(['search', 'page'], searchObject)],
   (current_user, search) => ({
     ...current_user,
     search

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -16,10 +16,11 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 import { Map, List, fromJS } from 'immutable';
+import omit from 'lodash/omit';
 
 import { search } from '../actions';
 
-export const initialState = Map({
+export const searchObject = Map({
   results: Map({
     geotags: Map({
       items: List([]),
@@ -37,18 +38,29 @@ export const initialState = Map({
       items: List([]),
       count: 0
     })
-  })
+  }),
+  query: Map({})
+});
+
+export const initialState = Map({
+  header: searchObject,
+  page: searchObject
 });
 
 export function reducer(state = initialState, action) {
   switch (action.type) {
-    case search.SET_SEARCH_RESULTS:
-      state = state.set('results', fromJS(action.payload.results));
+    case search.SET_SEARCH_RESULTS: {
+      const searchId = action.payload.more.searchId;
+      state = state.update(searchId, searchObject, s =>
+        s.merge(fromJS(omit(action.payload, ['more'])))
+      );
       break;
-
-    case search.CLEAR_SEARCH_RESULTS:
-      state = state.set('results', initialState.get('results'));
+    }
+    case search.CLEAR_SEARCH_RESULTS: {
+      const searchId = action.payload.searchId;
+      state = state.set(searchId, searchObject);
       break;
+    }
   }
 
   return state;

--- a/src/triggers/index.js
+++ b/src/triggers/index.js
@@ -810,10 +810,10 @@ export class ActionsTrigger {
     }
   }
 
-  search = async (query) => {
+  search = async (query, more) => {
     try {
       const response = await this.client.search(query);
-      this.dispatch(a.search.setSearchResults(response));
+      this.dispatch(a.search.setSearchResults(response, more));
     } catch (e) {
       this.dispatch(a.messages.addError(e.message));
     }

--- a/src/utils/tags.js
+++ b/src/utils/tags.js
@@ -38,6 +38,18 @@ export function convertModelsToTags(params = ImmutableMap({})) {
     });
   }
 
+
+  if (List.isList(params.get('locations'))) {
+    params.get('locations').forEach(function (tag) {
+      allTags.push({
+        urlId: tag.get('url_name'),
+        name: tag.get('name'),
+        postCount: tag.get('post_count'),
+        type: TAG_LOCATION
+      });
+    });
+  }
+
   if (List.isList(params.get('schools'))) {
     params.get('schools').forEach(function (school) {
       allTags.push({

--- a/test/integration/api/client.js
+++ b/test/integration/api/client.js
@@ -84,7 +84,7 @@ describe('Client test', () => {
   });
 
   it('#search works', async () => {
-    return expect(client.search({ q: 'test' }), 'to be rejected with', 'Search failed');
+    return expect(client.search({ q: 'test' }), 'to be rejected with', 'Not Found');
   });
 
   it('#userInfo works', async () => {


### PR DESCRIPTION
1. Server-side:

    - [x] Support picking desired results' types to fetch;
    - [x] Support required response's formatting:

    ```js
    {
      [String]: {
        /**
         * @count {Number} Total number of found entries
         * It can be better not to find out more than 100 items
         * because of performance reasons: what about just sending '99+' back?
         */
        count: Number,
        items: Array<Object>
      }
    }
    ```
    - [x] Support sorting by relevance;
    - [x] Support sorting by `updated_at` (add `updated_at` attribute to all indexes?);
    - [x] Support custom `limit` query parameter (`20` by default now);

2. Client-side:
    - [x] Implement two independent storages for search results (for header and page)
    - [x] Fix the bug with not updateable search bar (page);
    - [x] Full `offset`-based search results' management;