### PR TITLE
Client-side search fixes

### DIFF
--- a/src/less/blocks/search.less
+++ b/src/less/blocks/search.less
@@ -204,7 +204,7 @@
   }
 
   @media @fluidDesktopWide {
-    .list_item, .card__meta {
+    .page__content, .list_item, .card__meta {
       width: 740px;
     }
   }

--- a/src/triggers/index.js
+++ b/src/triggers/index.js
@@ -815,6 +815,7 @@ export class ActionsTrigger {
       const response = await this.client.search(query);
       this.dispatch(a.search.setSearchResults(response, more));
     } catch (e) {
+      this.dispatch(a.search.clearSearchResults(more.searchId));
       this.dispatch(a.messages.addError(e.message));
     }
   }


### PR DESCRIPTION
- [x] Put the search page's main content to the right place on `1600px` breakpoint.
- [x] Clear the search results storage if the request hasn't been failed.