### PR TITLE
Rewrite typedefs of loaders' handle methods

### DIFF
--- a/src/definitions/fetch-data.js
+++ b/src/definitions/fetch-data.js
@@ -20,4 +20,16 @@
 type nodeCallback = (e?: Error) => void;
 type replaceCallback = (url: string) => void;
 
-export type handler = (nextState: Object, replace?: replaceCallback, callback?: nodeCallback) => void|boolean;
+export type SyncHandler = (
+  nextState: Object,
+  replace?: replaceCallback,
+  callback?: nodeCallback
+) => void | boolean
+
+export type AsyncHandler = (
+  nextState: Object,
+  replace?: replaceCallback,
+  callback?: nodeCallback
+) => Promise<void | boolean>
+
+export type handler = SyncHandler | AsyncHandler;

--- a/src/definitions/fetch-data.js
+++ b/src/definitions/fetch-data.js
@@ -1,3 +1,22 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2017  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ @flow
+*/
 type nodeCallback = (e?: Error) => void;
 type replaceCallback = (url: string) => void;
 

--- a/src/definitions/fetch-data.js
+++ b/src/definitions/fetch-data.js
@@ -17,8 +17,8 @@
 
  @flow
 */
-type nodeCallback = (e?: Error) => void;
-type replaceCallback = (url: string) => void;
+export type nodeCallback = (e?: Error) => void;
+export type replaceCallback = (url: string) => void;
 
 export type SyncHandler = (
   nextState: Object,

--- a/src/utils/loader.js
+++ b/src/utils/loader.js
@@ -20,7 +20,10 @@ import { isPlainObject, isNumber } from 'lodash';
 import { browserHistory } from 'react-router';
 
 import type { Store } from 'redux';  // eslint-disable-line import/named
-import type { AsyncHandler, SyncHandler, handler } from '../definitions/fetch-data';
+import type {
+  nodeCallback, replaceCallback,
+  AsyncHandler, handler
+} from '../definitions/fetch-data';
 import type ApiClient from '../api/client';
 
 /**
@@ -93,7 +96,7 @@ export class AuthHandler {
     this.store = store;
   }
 
-  handle: AsyncHandler = async (nextState, replace) => {
+  handle = async (nextState: Object, replace: replaceCallback): Promise<boolean> => {
     const state = this.store.getState();
 
     if (state.getIn(['current_user', 'id']) === null
@@ -121,7 +124,7 @@ export class FetchHandler {
     this.apiClient = apiClient;
   }
 
-  handle: AsyncHandler = async (nextState) => {
+  handle = async (nextState: Object): Promise<void> => {
     const len = nextState.routes.length;
 
     for (let i = len; i--; i >= 0) {
@@ -148,7 +151,11 @@ export class FetchHandler {
     }
   };
 
-  handleSynchronously: SyncHandler = (nextState, replace, callback) => {
+  handleSynchronously = (
+    nextState: Object,
+    replace: replaceCallback,
+    callback: nodeCallback
+  ): void => {
     this.handle(nextState)
       .then(() => {
         if (callback) {


### PR DESCRIPTION
Closes #852.

However,
`flow-runtime: Failed to reveal unknown type in Temporal Dead Zone.` is still preserved.

That's because `Store` typedef isn't fetched: [`loader.js:22`](https://github.com/Lokiedu/libertysoil-site/blob/stable/src/utils/loader.js#L22)
Look at https://github.com/codemix/flow-runtime/issues/53