### PR TITLE
Add password change history

### DIFF
--- a/migrations/20170528234200_password_changes.js
+++ b/migrations/20170528234200_password_changes.js
@@ -1,0 +1,15 @@
+export async function up(knex) {
+  await knex.schema.createTable('password_changes', function (table) {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('user_id').index();
+    table.text('prev_hashed_password');
+    table.string('ip').comment('Should we use inet or cidr instead of string here?');
+    table.enu('event_type', ['change', 'reset']);
+    table.timestamp('created_at', true).defaultTo(knex.raw("(now() at time zone 'utc')"));
+    table.jsonb('more');
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.dropTable('password_changes');
+}

--- a/src/api/db/index.js
+++ b/src/api/db/index.js
@@ -100,6 +100,9 @@ export function initBookshelfFromKnex(knex) {
     outbox() {
       return this.hasMany(UserMessage, 'sender_id');
     },
+    password_changes() {
+      return this.hasMany(PasswordChange, 'user_id');
+    },
     virtuals: {
       gravatarHash() {
         const email = this.get('email');
@@ -694,6 +697,13 @@ export function initBookshelfFromKnex(knex) {
     }
   });
 
+  const PasswordChange = bookshelf.Model.extend({
+    tableName: 'password_changes',
+    user() {
+      return this.belongsTo(User, 'user_id');
+    },
+  });
+
   const Posts = bookshelf.Collection.extend({
     model: Post
   });
@@ -712,6 +722,7 @@ export function initBookshelfFromKnex(knex) {
   bookshelf.model('Quote', Quote);
   bookshelf.model('UserMessage', UserMessage);
   bookshelf.model('ProfilePost', ProfilePost);
+  bookshelf.model('PasswordChange', PasswordChange);
   bookshelf.collection('Posts', Posts);
 
   return bookshelf;


### PR DESCRIPTION
Each time user changes or resets their password a new entry is
inserted into the `password_changes` table.

Closes #726.