### PR TITLE
Tag subscription pages

### DIFF
--- a/src/actions/river.js
+++ b/src/actions/river.js
@@ -21,6 +21,10 @@ export const SET_POSTS_TO_RIVER = 'SET_POSTS_TO_RIVER';
 export const SET_POSTS_TO_LIKES_RIVER = 'SET_POSTS_TO_LIKES_RIVER';
 export const SET_POSTS_TO_FAVOURITES_RIVER = 'SET_POSTS_TO_FAVOURITES_RIVER';
 
+export const LOAD_HASHTAG_SUBSCRIPTONS_RIVER = 'LOAD_HASHTAG_SUBSCRIPTONS_RIVER';
+export const LOAD_SCHOOL_SUBSCRIPTONS_RIVER = 'LOAD_SCHOOL_SUBSCRIPTONS_RIVER';
+export const LOAD_GEOTAG_SUBSCRIPTONS_RIVER = 'LOAD_GEOTAG_SUBSCRIPTONS_RIVER';
+
 export function clearRiver() {
   return {
     type: CLEAR_RIVER
@@ -53,5 +57,35 @@ export function setPostsToFavouritesRiver(user_id, posts) {
       user_id,
       posts
     }
+  };
+}
+
+export function loadHashtagSubscriptionsRiver(posts, meta = { offset: 0 }) {
+  return {
+    type: LOAD_HASHTAG_SUBSCRIPTONS_RIVER,
+    payload: {
+      posts
+    },
+    meta
+  };
+}
+
+export function loadSchoolSubscriptionsRiver(posts, meta = { offset: 0 }) {
+  return {
+    type: LOAD_SCHOOL_SUBSCRIPTONS_RIVER,
+    payload: {
+      posts
+    },
+    meta
+  };
+}
+
+export function loadGeotagSubscriptionsRiver(posts, meta = { offset: 0 }) {
+  return {
+    type: LOAD_GEOTAG_SUBSCRIPTONS_RIVER,
+    payload: {
+      posts
+    },
+    meta
   };
 }

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -236,6 +236,21 @@ export default class ApiClient {
     return await response.json();
   }
 
+  async hashtagSubscriptions(query: Object = {}): Promise<Array<Post>> {
+    const response = await this.get(`/api/v1/posts/subscriptions/hashtag`, query);
+    return await response.json();
+  }
+
+  async schoolSubscriptions(query: Object = {}): Promise<Array<Post>> {
+    const response = await this.get(`/api/v1/posts/subscriptions/school`, query);
+    return await response.json();
+  }
+
+  async geotagSubscriptions(query: Object = {}): Promise<Array<Post>> {
+    const response = await this.get(`/api/v1/posts/subscriptions/geotag`, query);
+    return await response.json();
+  }
+
   async allPosts(query: Object = {}): Promise<Array<Post>> {
     const response = await this.get('/api/v1/posts/all', query);
     return await response.json();

--- a/src/api/routing.js
+++ b/src/api/routing.js
@@ -37,6 +37,9 @@ export function initApi(bookshelf, sphinx) {
   api.post('/session', controller.login);
 
   api.get('/posts', controller.subscriptions);
+  api.get('/posts/subscriptions/hashtag', controller.hashtagSubscriptions);
+  api.get('/posts/subscriptions/school', controller.schoolSubscriptions);
+  api.get('/posts/subscriptions/geotag', controller.geotagSubscriptions);
   api.post('/posts', controller.createPost);
   api.get('/post/:id', controller.getPost);
   api.post('/post/:id', controller.updatePost);

--- a/src/components/tags-inform/index.js
+++ b/src/components/tags-inform/index.js
@@ -62,19 +62,19 @@ export default class TagsInform extends React.Component {
         className: 'navigation-item--color_green',
         list: current_user.get('followed_geotags').toList().sort(compareTagsByDate).take(4),
         icon: { icon: 'place' },
-        url: '/geo/'
+        url: '/feed/geo'
       },
       hashtags: {
         className: 'navigation-item--color_blue',
         list: current_user.get('followed_hashtags').toList().sort(compareTagsByDate).take(6),
         icon: { icon: 'hashtag' },
-        url: '/tag/'
+        url: '/feed/tag'
       },
       schools: {
         className: 'navigation-item--color_red',
         list: current_user.get('followed_schools').toList().sort(compareTagsByDate).take(4),
         icon: { icon: 'school' },
-        url: '/s/'
+        url: '/feed/s'
       }
     };
   }

--- a/src/components/tags-inform/index.js
+++ b/src/components/tags-inform/index.js
@@ -20,6 +20,17 @@ import { omit } from 'lodash';
 
 import TagsInformNormal from './normal';
 
+
+function compareTagsByDate(lhs, rhs) {
+  const lhsDate = new Date(lhs.get('updated_at'));
+  const rhsDate = new Date(rhs.get('updated_at'));
+
+  if (lhsDate > rhsDate) { return -1; }
+  if (lhsDate < rhsDate) { return 1; }
+
+  return 0;
+}
+
 /**
  * Navigation-like block displaying number of unread posts
  * per each group of tags (geotags, schools, hashtags)
@@ -49,19 +60,19 @@ export default class TagsInform extends React.Component {
     return {
       geotags: {
         className: 'navigation-item--color_green',
-        list: current_user.get('followed_geotags').toList().take(4),
+        list: current_user.get('followed_geotags').toList().sort(compareTagsByDate).take(4),
         icon: { icon: 'place' },
         url: '/geo/'
       },
       hashtags: {
         className: 'navigation-item--color_blue',
-        list: current_user.get('followed_hashtags').toList().take(6),
+        list: current_user.get('followed_hashtags').toList().sort(compareTagsByDate).take(6),
         icon: { icon: 'hashtag' },
         url: '/tag/'
       },
       schools: {
         className: 'navigation-item--color_red',
-        list: current_user.get('followed_schools').toList().take(4),
+        list: current_user.get('followed_schools').toList().sort(compareTagsByDate).take(4),
         icon: { icon: 'school' },
         url: '/s/'
       }

--- a/src/components/tags-inform/normal.js
+++ b/src/components/tags-inform/normal.js
@@ -40,6 +40,7 @@ const TagsInformNormal = ({ animated, tags, truncated, ...props }) => (
             key={tagTypeTitle}
             theme="2.0"
             truncated={truncated}
+            to={tagType.url}
           >
             <TagCloud
               className="tags--row tags--queue"

--- a/src/pages/geotag-subscriptions.js
+++ b/src/pages/geotag-subscriptions.js
@@ -1,0 +1,187 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import Helmet from 'react-helmet';
+
+import { API_HOST } from '../config';
+import ApiClient from '../api/client';
+
+import {
+  Page,
+  PageMain,
+  PageBody,
+  PageContent
+} from '../components/page';
+import CreatePost from '../components/create-post';
+import Header from '../components/header';
+import HeaderLogo from '../components/header-logo';
+import Footer from '../components/footer';
+import Sidebar from '../components/sidebar';
+import SidebarAlt from '../components/sidebarAlt';
+import LoadableRiver from '../components/loadable-river';
+import Breadcrumbs from '../components/breadcrumbs/breadcrumbs';
+import SideSuggestedUsers from '../components/side-suggested-users';
+import { ActionsTrigger } from '../triggers';
+import { createSelector, currentUserSelector } from '../selectors';
+import {
+  resetCreatePostForm,
+  updateCreatePostForm
+} from '../actions/posts';
+
+
+export const LOAD_MORE_LIMIT = 4;
+
+class GeotagSubscriptionsPage extends React.Component {
+  static async fetchData(router, store, client) {
+    const trigger = new ActionsTrigger(client, store.dispatch);
+
+    await Promise.all([
+      trigger.loadGeotagSubscriptions(),
+      trigger.loadPersonalizedSuggestions(),
+      trigger.loadUserRecentTags()
+    ]);
+  }
+
+  constructor(props, ...args) {
+    super(props, ...args);
+
+    this.triggers = new ActionsTrigger(
+      new ApiClient(API_HOST),
+      props.dispatch
+    );
+  }
+
+  handleForceLoadPosts = async () => {
+    const { river } = this.props;
+    const res = await this.triggers.loadGeotagSubscriptions({ offset: river.size, limit: LOAD_MORE_LIMIT });
+    return Array.isArray(res) && res.length > LOAD_MORE_LIMIT;
+  }
+
+  handleAutoLoadPosts = async (isVisible) => {
+    if (!isVisible) {
+      return undefined;
+    }
+
+    const { river, ui } = this.props;
+    let displayLoadMore = true;
+    if (isVisible && !ui.getIn(['progress', 'loadGeotagSubscriptionsRiver'])) {
+      const res = await this.triggers.loadGeotagSubscriptions({ offset: river.size, limit: LOAD_MORE_LIMIT });
+      displayLoadMore = Array.isArray(res) && res.length > LOAD_MORE_LIMIT;
+    }
+
+    return displayLoadMore;
+  };
+
+  render() {
+    const {
+      create_post_form,
+      current_user,
+      ui,
+      resetCreatePostForm,
+      updateCreatePostForm
+    } = this.props;
+
+    const actions = { resetCreatePostForm, updateCreatePostForm };
+    const i_am_following = this.props.following.get(current_user.get('id'));
+
+    return (
+      <div>
+        <Helmet title="Geotag Subscriptions of " />
+        <Header
+          current_user={current_user}
+          is_logged_in={this.props.is_logged_in}
+        >
+          <HeaderLogo />
+          <Breadcrumbs title="Geotag Subscriptions" />
+        </Header>
+
+        <Page>
+          <PageMain>
+            <PageBody>
+              <Sidebar />
+              <PageContent>
+                <CreatePost
+                  actions={actions}
+                  addedGeotags={create_post_form.get('geotags')}
+                  addedHashtags={create_post_form.get('hashtags')}
+                  addedSchools={create_post_form.get('schools')}
+                  defaultText={create_post_form.get('text')}
+                  triggers={this.triggers}
+                  userRecentTags={current_user.get('recent_tags')}
+                />
+                <LoadableRiver
+                  comments={this.props.comments}
+                  current_user={current_user}
+                  loadMoreLimit={LOAD_MORE_LIMIT}
+                  posts={this.props.posts}
+                  river={this.props.river}
+                  triggers={this.triggers}
+                  ui={ui}
+                  users={this.props.users}
+                  waiting={ui.getIn(['progress', 'loadGeotagSubscriptionsRiver'])}
+                  onAutoLoad={this.handleAutoLoadPosts}
+                  onForceLoad={this.handleForceLoadPosts}
+                />
+              </PageContent>
+              <SidebarAlt>
+                <SideSuggestedUsers
+                  current_user={current_user}
+                  i_am_following={i_am_following}
+                  triggers={this.triggers}
+                  users={current_user.get('suggested_users')}
+                />
+              </SidebarAlt>
+            </PageBody>
+          </PageMain>
+        </Page>
+
+        <Footer />
+      </div>
+    );
+  }
+}
+
+const selector = createSelector(
+  currentUserSelector,
+  state => state.get('comments'),
+  state => state.get('create_post_form'),
+  state => state.get('following'),
+  state => state.get('posts'),
+  state => state.getIn(['tag_subscriptions', 'geotag_subscriptions_river']),
+  state => state.get('schools'),
+  state => state.get('users'),
+  state => state.get('ui'),
+  (current_user, comments, create_post_form, following, posts, river, schools, users, ui) => ({
+    ...current_user,
+    comments,
+    create_post_form,
+    following,
+    posts,
+    river,
+    schools,
+    users,
+    ui
+  })
+);
+
+export default connect(selector, dispatch => ({
+  dispatch,
+  ...bindActionCreators({ resetCreatePostForm, updateCreatePostForm }, dispatch)
+}))(GeotagSubscriptionsPage);

--- a/src/pages/hashtag-subscriptions.js
+++ b/src/pages/hashtag-subscriptions.js
@@ -1,0 +1,187 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import Helmet from 'react-helmet';
+
+import { API_HOST } from '../config';
+import ApiClient from '../api/client';
+
+import {
+  Page,
+  PageMain,
+  PageBody,
+  PageContent
+} from '../components/page';
+import CreatePost from '../components/create-post';
+import Header from '../components/header';
+import HeaderLogo from '../components/header-logo';
+import Footer from '../components/footer';
+import Sidebar from '../components/sidebar';
+import SidebarAlt from '../components/sidebarAlt';
+import LoadableRiver from '../components/loadable-river';
+import Breadcrumbs from '../components/breadcrumbs/breadcrumbs';
+import SideSuggestedUsers from '../components/side-suggested-users';
+import { ActionsTrigger } from '../triggers';
+import { createSelector, currentUserSelector } from '../selectors';
+import {
+  resetCreatePostForm,
+  updateCreatePostForm
+} from '../actions/posts';
+
+
+export const LOAD_MORE_LIMIT = 4;
+
+class HashtagSubscriptionsPage extends React.Component {
+  static async fetchData(router, store, client) {
+    const trigger = new ActionsTrigger(client, store.dispatch);
+
+    await Promise.all([
+      trigger.loadHashtagSubscriptions(),
+      trigger.loadPersonalizedSuggestions(),
+      trigger.loadUserRecentTags()
+    ]);
+  }
+
+  constructor(props, ...args) {
+    super(props, ...args);
+
+    this.triggers = new ActionsTrigger(
+      new ApiClient(API_HOST),
+      props.dispatch
+    );
+  }
+
+  handleForceLoadPosts = async () => {
+    const { river } = this.props;
+    const res = await this.triggers.loadHashtagSubscriptions({ offset: river.size, limit: LOAD_MORE_LIMIT });
+    return Array.isArray(res) && res.length > LOAD_MORE_LIMIT;
+  }
+
+  handleAutoLoadPosts = async (isVisible) => {
+    if (!isVisible) {
+      return undefined;
+    }
+
+    const { river, ui } = this.props;
+    let displayLoadMore = true;
+    if (isVisible && !ui.getIn(['progress', 'loadHashtagSubscriptionsRiver'])) {
+      const res = await this.triggers.loadHashtagSubscriptions({ offset: river.size, limit: LOAD_MORE_LIMIT });
+      displayLoadMore = Array.isArray(res) && res.length > LOAD_MORE_LIMIT;
+    }
+
+    return displayLoadMore;
+  };
+
+  render() {
+    const {
+      create_post_form,
+      current_user,
+      ui,
+      resetCreatePostForm,
+      updateCreatePostForm
+    } = this.props;
+
+    const actions = { resetCreatePostForm, updateCreatePostForm };
+    const i_am_following = this.props.following.get(current_user.get('id'));
+
+    return (
+      <div>
+        <Helmet title="Hashtag Subscriptions of " />
+        <Header
+          current_user={current_user}
+          is_logged_in={this.props.is_logged_in}
+        >
+          <HeaderLogo />
+          <Breadcrumbs title="Hashtag Subscriptions" />
+        </Header>
+
+        <Page>
+          <PageMain>
+            <PageBody>
+              <Sidebar />
+              <PageContent>
+                <CreatePost
+                  actions={actions}
+                  addedGeotags={create_post_form.get('geotags')}
+                  addedHashtags={create_post_form.get('hashtags')}
+                  addedSchools={create_post_form.get('schools')}
+                  defaultText={create_post_form.get('text')}
+                  triggers={this.triggers}
+                  userRecentTags={current_user.get('recent_tags')}
+                />
+                <LoadableRiver
+                  comments={this.props.comments}
+                  current_user={current_user}
+                  loadMoreLimit={LOAD_MORE_LIMIT}
+                  posts={this.props.posts}
+                  river={this.props.river}
+                  triggers={this.triggers}
+                  ui={ui}
+                  users={this.props.users}
+                  waiting={ui.getIn(['progress', 'loadHashtagSubscriptionsRiver'])}
+                  onAutoLoad={this.handleAutoLoadPosts}
+                  onForceLoad={this.handleForceLoadPosts}
+                />
+              </PageContent>
+              <SidebarAlt>
+                <SideSuggestedUsers
+                  current_user={current_user}
+                  i_am_following={i_am_following}
+                  triggers={this.triggers}
+                  users={current_user.get('suggested_users')}
+                />
+              </SidebarAlt>
+            </PageBody>
+          </PageMain>
+        </Page>
+
+        <Footer />
+      </div>
+    );
+  }
+}
+
+const selector = createSelector(
+  currentUserSelector,
+  state => state.get('comments'),
+  state => state.get('create_post_form'),
+  state => state.get('following'),
+  state => state.get('posts'),
+  state => state.getIn(['tag_subscriptions', 'hashtag_subscriptions_river']),
+  state => state.get('schools'),
+  state => state.get('users'),
+  state => state.get('ui'),
+  (current_user, comments, create_post_form, following, posts, river, schools, users, ui) => ({
+    ...current_user,
+    comments,
+    create_post_form,
+    following,
+    posts,
+    river,
+    schools,
+    users,
+    ui
+  })
+);
+
+export default connect(selector, dispatch => ({
+  dispatch,
+  ...bindActionCreators({ resetCreatePostForm, updateCreatePostForm }, dispatch)
+}))(HashtagSubscriptionsPage);

--- a/src/pages/school-subscriptions.js
+++ b/src/pages/school-subscriptions.js
@@ -1,0 +1,187 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2016  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import Helmet from 'react-helmet';
+
+import { API_HOST } from '../config';
+import ApiClient from '../api/client';
+
+import {
+  Page,
+  PageMain,
+  PageBody,
+  PageContent
+} from '../components/page';
+import CreatePost from '../components/create-post';
+import Header from '../components/header';
+import HeaderLogo from '../components/header-logo';
+import Footer from '../components/footer';
+import Sidebar from '../components/sidebar';
+import SidebarAlt from '../components/sidebarAlt';
+import LoadableRiver from '../components/loadable-river';
+import Breadcrumbs from '../components/breadcrumbs/breadcrumbs';
+import SideSuggestedUsers from '../components/side-suggested-users';
+import { ActionsTrigger } from '../triggers';
+import { createSelector, currentUserSelector } from '../selectors';
+import {
+  resetCreatePostForm,
+  updateCreatePostForm
+} from '../actions/posts';
+
+
+export const LOAD_MORE_LIMIT = 4;
+
+class SchoolSubscriptionsPage extends React.Component {
+  static async fetchData(router, store, client) {
+    const trigger = new ActionsTrigger(client, store.dispatch);
+
+    await Promise.all([
+      trigger.loadSchoolSubscriptions(),
+      trigger.loadPersonalizedSuggestions(),
+      trigger.loadUserRecentTags()
+    ]);
+  }
+
+  constructor(props, ...args) {
+    super(props, ...args);
+
+    this.triggers = new ActionsTrigger(
+      new ApiClient(API_HOST),
+      props.dispatch
+    );
+  }
+
+  handleForceLoadPosts = async () => {
+    const { river } = this.props;
+    const res = await this.triggers.loadSchoolSubscriptions({ offset: river.size, limit: LOAD_MORE_LIMIT });
+    return Array.isArray(res) && res.length > LOAD_MORE_LIMIT;
+  }
+
+  handleAutoLoadPosts = async (isVisible) => {
+    if (!isVisible) {
+      return undefined;
+    }
+
+    const { river, ui } = this.props;
+    let displayLoadMore = true;
+    if (isVisible && !ui.getIn(['progress', 'loadSchoolSubscriptionsRiver'])) {
+      const res = await this.triggers.loadSchoolSubscriptions({ offset: river.size, limit: LOAD_MORE_LIMIT });
+      displayLoadMore = Array.isArray(res) && res.length > LOAD_MORE_LIMIT;
+    }
+
+    return displayLoadMore;
+  };
+
+  render() {
+    const {
+      create_post_form,
+      current_user,
+      ui,
+      resetCreatePostForm,
+      updateCreatePostForm
+    } = this.props;
+
+    const actions = { resetCreatePostForm, updateCreatePostForm };
+    const i_am_following = this.props.following.get(current_user.get('id'));
+
+    return (
+      <div>
+        <Helmet title="School Subscriptions of " />
+        <Header
+          current_user={current_user}
+          is_logged_in={this.props.is_logged_in}
+        >
+          <HeaderLogo />
+          <Breadcrumbs title="School Subscriptions" />
+        </Header>
+
+        <Page>
+          <PageMain>
+            <PageBody>
+              <Sidebar />
+              <PageContent>
+                <CreatePost
+                  actions={actions}
+                  addedGeotags={create_post_form.get('geotags')}
+                  addedHashtags={create_post_form.get('hashtags')}
+                  addedSchools={create_post_form.get('schools')}
+                  defaultText={create_post_form.get('text')}
+                  triggers={this.triggers}
+                  userRecentTags={current_user.get('recent_tags')}
+                />
+                <LoadableRiver
+                  comments={this.props.comments}
+                  current_user={current_user}
+                  loadMoreLimit={LOAD_MORE_LIMIT}
+                  posts={this.props.posts}
+                  river={this.props.river}
+                  triggers={this.triggers}
+                  ui={ui}
+                  users={this.props.users}
+                  waiting={ui.getIn(['progress', 'loadSchoolSubscriptionsRiver'])}
+                  onAutoLoad={this.handleAutoLoadPosts}
+                  onForceLoad={this.handleForceLoadPosts}
+                />
+              </PageContent>
+              <SidebarAlt>
+                <SideSuggestedUsers
+                  current_user={current_user}
+                  i_am_following={i_am_following}
+                  triggers={this.triggers}
+                  users={current_user.get('suggested_users')}
+                />
+              </SidebarAlt>
+            </PageBody>
+          </PageMain>
+        </Page>
+
+        <Footer />
+      </div>
+    );
+  }
+}
+
+const selector = createSelector(
+  currentUserSelector,
+  state => state.get('comments'),
+  state => state.get('create_post_form'),
+  state => state.get('following'),
+  state => state.get('posts'),
+  state => state.getIn(['tag_subscriptions', 'school_subscriptions_river']),
+  state => state.get('schools'),
+  state => state.get('users'),
+  state => state.get('ui'),
+  (current_user, comments, create_post_form, following, posts, river, schools, users, ui) => ({
+    ...current_user,
+    comments,
+    create_post_form,
+    following,
+    posts,
+    river,
+    schools,
+    users,
+    ui
+  })
+);
+
+export default connect(selector, dispatch => ({
+  dispatch,
+  ...bindActionCreators({ resetCreatePostForm, updateCreatePostForm }, dispatch)
+}))(SchoolSubscriptionsPage);

--- a/src/routing.js
+++ b/src/routing.js
@@ -59,6 +59,9 @@ import NewSchoolToolPage from './pages/tools/new-school-tool';
 import ConversationsToolPage from './pages/tools/conversations-tool';
 import SearchPage from './pages/search';
 import AllPostsPage from './pages/all-posts';
+import HashtagSubscriptionsPage from './pages/hashtag-subscriptions';
+import SchoolSubscriptionsPage from './pages/school-subscriptions';
+import GeotagSubscriptionsPage from './pages/geotag-subscriptions';
 
 import ListPage from './pages/list';
 import Induction from './pages/induction';
@@ -79,6 +82,9 @@ export function getRoutes(authHandler, fetchHandler) {
       <Route path="/" component={IndexPage} onEnter={withoutAuth} />
       <Route component={AllPostsPage} path="/all" onEnter={withoutAuth} />
       <Route component={ListPage} path="/feed" onEnter={withAuth} />
+      <Route component={HashtagSubscriptionsPage} path="/feed/tag" onEnter={withAuth} />
+      <Route component={SchoolSubscriptionsPage} path="/feed/s" onEnter={withAuth} />
+      <Route component={GeotagSubscriptionsPage} path="/feed/geo" onEnter={withAuth} />
       <Route component={Induction} path="/induction" onEnter={withAuth} />
       <Route component={SuggestionsPage} path="/suggestions" onEnter={withAuth} />
       <Route component={Welcome} path="/welcome" onEnter={withoutAuth} />

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -56,6 +56,7 @@ import * as tools from './tools';
 import * as user_messages from './user_messages';
 import * as profile_posts from './profile_posts';
 import * as continent_nav from './continent_nav';
+import * as tag_subscriptions from './tag_subscriptions';
 
 
 export const theReducer = combineReducers(i.Map({
@@ -94,7 +95,8 @@ export const theReducer = combineReducers(i.Map({
   continent_nav: continent_nav.reducer,
   tools: tools.reducer,
   user_messages: user_messages.reducer,
-  profile_posts: profile_posts.reducer
+  profile_posts: profile_posts.reducer,
+  tag_subscriptions: tag_subscriptions.reducer,
 }));
 
 const initialState = i.Map({
@@ -147,6 +149,7 @@ const initialState = i.Map({
   user_messages: user_messages.initialState,
   profile_posts: profile_posts.initialState,
   continent_nav: continent_nav.initialState,
+  tag_subscriptions: tag_subscriptions.initialState,
 });
 
 const browserHasDevTools = typeof window === 'object' && typeof window.devToolsExtension !== 'undefined';

--- a/src/store/posts.js
+++ b/src/store/posts.js
@@ -41,6 +41,9 @@ export default function reducer(state = initialState, action) {
     case a.river.SET_POSTS_TO_RIVER:
     case a.river.SET_POSTS_TO_LIKES_RIVER:
     case a.river.SET_POSTS_TO_FAVOURITES_RIVER:
+    case a.river.LOAD_HASHTAG_SUBSCRIPTONS_RIVER:
+    case a.river.LOAD_SCHOOL_SUBSCRIPTONS_RIVER:
+    case a.river.LOAD_GEOTAG_SUBSCRIPTONS_RIVER:
     case a.posts.SET_USER_POSTS:
     case a.hashtags.SET_HASHTAG_POSTS:
     case a.schools.SET_SCHOOL_POSTS:

--- a/src/store/tag_subscriptions.js
+++ b/src/store/tag_subscriptions.js
@@ -1,0 +1,61 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2015  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import i from 'immutable';
+
+import { river } from '../actions';
+
+export const initialState = i.fromJS({
+  hashtag_subscriptions_river: [],
+  school_subscriptions_river: [],
+  geotag_subscriptions_river: [],
+});
+
+function updateRiver(state, action, key) {
+  const postIds = action.payload.posts.map(post => post.id);
+  const offset = action.meta.offset;
+
+  if (offset === 0) {
+    return state.set(key, i.List(postIds));
+  }
+
+  return state.update(key, river => {
+    return river.splice(offset, 0, ...postIds);
+  });
+}
+
+export function reducer(state = initialState, action) {
+  switch (action.type) {
+    case river.LOAD_HASHTAG_SUBSCRIPTONS_RIVER: {
+      state = updateRiver(state, action, 'hashtag_subscriptions_river');
+      break;
+    }
+
+    case river.LOAD_SCHOOL_SUBSCRIPTONS_RIVER: {
+      state = updateRiver(state, action, 'school_subscriptions_river');
+      break;
+    }
+
+    case river.LOAD_GEOTAG_SUBSCRIPTONS_RIVER: {
+      state = updateRiver(state, action, 'geotag_subscriptions_river');
+      break;
+    }
+  }
+
+  return state;
+}
+

--- a/src/triggers/index.js
+++ b/src/triggers/index.js
@@ -632,6 +632,60 @@ export class ActionsTrigger {
     }
   };
 
+  loadHashtagSubscriptions = async (query = { offset: 0 }) => {
+    this.dispatch(a.ui.setProgress('loadHashtagSubscriptionsRiver'), true);
+
+    let result;
+
+    try {
+      result = await this.client.hashtagSubscriptions(query);
+      this.dispatch(a.river.loadHashtagSubscriptionsRiver(result));
+    } catch (e) {
+      this.dispatch(a.messages.reportError(a.river.LOAD_HASHTAG_SUBSCRIPTONS_RIVER, e));
+      result = false;
+    }
+
+    this.dispatch(a.ui.setProgress('loadHashtagSubscriptionsRiver'), false);
+
+    return result;
+  }
+
+  loadSchoolSubscriptions = async (query = { offset: 0 }) => {
+    this.dispatch(a.ui.setProgress('loadSchoolSubscriptionsRiver'), true);
+
+    let result;
+
+    try {
+      result = await this.client.schoolSubscriptions(query);
+      this.dispatch(a.river.loadSchoolSubscriptionsRiver(result));
+    } catch (e) {
+      this.dispatch(a.messages.reportError(a.river.LOAD_SCHOOL_SUBSCRIPTONS_RIVER, e));
+      result = false;
+    }
+
+    this.dispatch(a.ui.setProgress('loadSchoolSubscriptionsRiver'), false);
+
+    return result;
+  }
+
+  loadGeotagSubscriptions = async (query = { offset: 0 }) => {
+    this.dispatch(a.ui.setProgress('loadGeotagSubscriptionsRiver'), true);
+
+    let result;
+
+    try {
+      result = await this.client.geotagSubscriptions(query);
+      this.dispatch(a.river.loadGeotagSubscriptionsRiver(result));
+    } catch (e) {
+      this.dispatch(a.messages.reportError(a.river.LOAD_GEOTAG_SUBSCRIPTONS_RIVER, e));
+      result = false;
+    }
+
+    this.dispatch(a.ui.setProgress('loadGeotagSubscriptionsRiver'), false);
+
+    return result;
+  }
+
   loadTagCloud = async () => {
     try {
       const result = await this.client.tagCloud();

--- a/test/integration/triggers/post.js
+++ b/test/integration/triggers/post.js
@@ -1,0 +1,150 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2015  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-env node, mocha */
+import { serialize } from 'cookie';
+
+import expect from '../../../test-helpers/expect';
+import { initState } from '../../../src/store';
+import { ActionsTrigger } from '../../../src/triggers';
+import ApiClient from '../../../src/api/client';
+import { API_HOST } from '../../../src/config';
+import { createUser } from '../../../test-helpers/factories/user';
+import { createPost } from '../../../test-helpers/factories/post';
+import HashtagFactory from '../../../test-helpers/factories/hashtag';
+import SchoolFactory from '../../../test-helpers/factories/school';
+import GeotagFactory from '../../../test-helpers/factories/geotag';
+import { login } from '../../../test-helpers/api';
+
+
+describe('subscriptions', () => {
+  let user, otherUser, client;
+  let triggers, store, post;
+
+  before(async () => {
+    user = await createUser();
+    otherUser = await createUser();
+    const sessionId = await login(user.get('username'), user.get('password'));
+    const headers = {
+      "cookie": serialize('connect.sid', sessionId)
+    };
+    client = new ApiClient(API_HOST, { headers });
+  });
+
+  after(async () => {
+    await user.destroy();
+    await otherUser.destroy();
+  });
+
+  beforeEach(async () => {
+    store = initState();
+    triggers = new ActionsTrigger(client, store.dispatch);
+    post = await createPost({ user_id: otherUser.id });
+  });
+
+  afterEach(async () => {
+    await post.destroy();
+  });
+
+  describe('"loadHashtagSubscriptions" trigger', () => {
+    let hashtag;
+
+    beforeEach(async () => {
+      hashtag = await post.hashtags().create(HashtagFactory.build());
+      await user.followed_hashtags().attach(hashtag.id);
+    });
+
+    afterEach(async () => {
+      await hashtag.destroy();
+    });
+
+    it('adds posts to the posts storage and post ids to river', async () => {
+      await triggers.loadHashtagSubscriptions();
+
+      expect(
+        store.getState().getIn(['tag_subscriptions', 'hashtag_subscriptions_river']).toJS(),
+        'to satisfy',
+        [post.id]
+      );
+
+      expect(
+        store.getState().get('posts').toJS(),
+        'to satisfy',
+        { [post.id]: { id: post.id } }
+      );
+    });
+  });
+
+  describe('"loadSchoolSubscriptions" trigger', () => {
+    let school;
+
+    beforeEach(async () => {
+      school = await post.schools().create(SchoolFactory.build());
+      await user.followed_schools().attach(school.id);
+    });
+
+    afterEach(async () => {
+      await school.destroy();
+    });
+
+    it('adds posts to the posts storage and post ids to river', async () => {
+      await triggers.loadSchoolSubscriptions();
+
+      expect(
+        store.getState().getIn(['tag_subscriptions', 'school_subscriptions_river']).toJS(),
+        'to satisfy',
+        [post.id]
+      );
+
+      expect(
+        store.getState().get('posts').toJS(),
+        'to satisfy',
+        { [post.id]: { id: post.id } }
+      );
+    });
+  });
+
+  describe('"loadGeotagSubscriptions" trigger', () => {
+    let geotag;
+
+    beforeEach(async () => {
+      geotag = await post.geotags().create(GeotagFactory.build());
+      await user.followed_geotags().attach(geotag.id);
+    });
+
+    afterEach(async () => {
+      await geotag.destroy();
+    });
+
+    it('adds posts to the posts storage and post ids to river', async () => {
+      await triggers.loadGeotagSubscriptions();
+
+      expect(
+        store.getState().getIn(['tag_subscriptions', 'geotag_subscriptions_river']).toJS(),
+        'to satisfy',
+        [post.id]
+      );
+
+      expect(
+        store.getState().get('posts').toJS(),
+        'to satisfy',
+        { [post.id]: { id: post.id } }
+      );
+    });
+  });
+});
+


### PR DESCRIPTION
Adds pages for displaying all posts of all followed subscribed tags.

- [x] Fix the order of followed tags on sidebar.
- [x] Add controllers that respond with posts of all followed tags.
- [x] Add redux storages for each type of tag.
- [x] Add pages for displaying tag subscriptions.
  - [x] Make icons on the sidebar clickable.
- [ ] Fix controllers after #868 is merged.