### PR TITLE
Story post backend

### DIFF
--- a/migrations/20170615170503_posts.js
+++ b/migrations/20170615170503_posts.js
@@ -1,0 +1,19 @@
+export async function up(knex) {
+  await knex.schema.table('posts', table => {
+    table.text('text_source');
+    table.string('text_type');
+  });
+
+  // set text_source and more.shortText
+  await knex.raw(`
+    UPDATE posts SET
+      text_source = text,
+      more = jsonb_set(coalesce(more, jsonb_object('{}')), '{shortText}', to_jsonb((regexp_split_to_array(text, E'\\n{2,}'))[1]))
+  `);
+}
+
+export async function down(knex) {
+  await knex.schema.table('posts', table => {
+    table.dropColumns(['text_source', 'text_type']);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "redux": "~3.6.0",
     "redux-immutablejs": "0.0.8",
     "reselect": "~3.0.0",
+    "sanitize-html": "^1.14.1",
     "sendgrid": "^2.0.0",
     "slug": "^0.9.1",
     "smoothscroll-polyfill": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "gm": "^1.23.0",
     "grapheme-breaker": "^0.3.2",
     "grapheme-utils": "^0.1.0",
+    "htmlparser2": "^3.9.2",
     "immutable": "^3.7.5",
     "isomorphic-fetch": "^2.2.1",
     "kcors": "~2.2.0",

--- a/src/api/db/index.js
+++ b/src/api/db/index.js
@@ -184,9 +184,9 @@ export function initBookshelfFromKnex(knex) {
   const Post = bookshelf.Model.extend({
     tableName: 'posts',
     initialize() {
-      this.on('saving', this.renderText.bind(this));
+      this.on('saving', this.updateAttributes.bind(this));
     },
-    renderText() {
+    updateAttributes() {
       const source = this.get('text_source');
       if (!_.isString(source) || _.isEmpty(source)) {
         return;

--- a/src/components/create-post.js
+++ b/src/components/create-post.js
@@ -105,7 +105,7 @@ class CreatePost extends React.Component {
     this.isSubmitting = true;
 
     const data = {
-      text: fields.text.value,
+      text_source: fields.text.value,
       hashtags: this.props.addedHashtags.map(hashtag => hashtag.get('name')).toJS(),
       schools: this.props.addedSchools.map(school => school.get('name')).toJS(),
       geotags: this.props.addedGeotags.map(geotag => geotag.get('id')).toJS(),

--- a/src/components/edit-post.js
+++ b/src/components/edit-post.js
@@ -136,7 +136,7 @@ export default class EditPost extends React.Component {
 
     const form = this.form;
     const data = {
-      text: form.text.value,
+      text_source: form.text.value,
       hashtags: this.props.hashtags.map(hashtag => hashtag.get('name')).toJS(),
       schools: this.props.schools.map(school => school.get('name')).toJS(),
       geotags: this.props.geotags.map(geotag => geotag.get('id')).toJS(),

--- a/test-helpers/factories/user.js
+++ b/test-helpers/factories/user.js
@@ -17,7 +17,11 @@ const UserFactory = new Factory()
   .attr('password', () => faker.internet.password())
   .attr('hashed_password', ['password'], password => bcrypt.hashSync(password, 10))
   .attr('email_check_hash', '')
-  .attr('more', { first_login: false });
+  .attr('more', {
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    first_login: false
+  });
 
 export default UserFactory;
 

--- a/test/integration/anonym-access.js
+++ b/test/integration/anonym-access.js
@@ -1,14 +1,8 @@
 /*eslint-env node, mocha */
-/*global $dbConfig */
-import uuid from 'uuid';
 //import sinon from 'sinon';
 
 import expect from '../../test-helpers/expect';
-import initBookshelf from '../../src/api/db';
-
-
-const bookshelf = initBookshelf($dbConfig);
-const User = bookshelf.model('User');
+import { createUser } from '../../test-helpers/factories/user';
 
 describe('pages that are available for anonym', function () {
   // before(() => {
@@ -21,21 +15,17 @@ describe('pages that are available for anonym', function () {
 
 
   describe('when user is not logged in', function () {
+    let user;
     beforeEach(async function () {
-      await new User({
-        id: uuid.v4(),
-        username: 'john',
-        more: '{"lastName": "Smith", "firstName": "John", "first_login": false}',
-        email: 'john@example.com'
-      }).save(null, { method: 'insert' });
+      user = await createUser();
     });
 
     afterEach(async function () {
-      await bookshelf.knex.raw('DELETE FROM users WHERE username=\'john\';');
+      await user.destroy();
     });
 
     it('User profile page works', async function () {
-      return expect(`/user/john`, 'body to contain', 'John Smith');
+      await expect(`/user/${user.get('username')}`, 'body to contain', user.fullName);
     });
   });
 });

--- a/test/integration/api.js
+++ b/test/integration/api.js
@@ -24,6 +24,7 @@ import bcrypt from 'bcrypt';
 import bb from 'bluebird';
 import FormData from 'form-data';
 import AWS from 'mock-aws';
+import { reverse } from 'lodash';
 
 import enLocalization from '../../res/locale/en';
 
@@ -342,14 +343,14 @@ describe('api v.1', () => {
           it('First page of subscriptions should return by-default', async () => {
             await expect(
               { url: `/api/v1/posts`, session: sessionId },
-              'body to satisfy', [{ text: 'This is a Post #10' }, { text: 'This is a Post #9' }, { text: 'This is a Post #8' }, { text: 'This is a Post #7' }, { text: 'This is a Post #6' }]
+              'body to satisfy', reverse(posts.slice(5).map(post => ({ id: post.id })))
             );
           });
 
           it('Other pages of subscriptions should work', async () => {
             await expect(
               { url: `/api/v1/posts?offset=4`, session: sessionId },
-              'body to satisfy', [{ text: 'This is a Post #6' }, { text: 'This is a Post #5' }, { text: 'This is a Post #4' }, { text: 'This is a Post #3' }, { text: 'This is a Post #2' }]
+              'body to satisfy', reverse(posts.slice(1, 6).map(post => ({ id: post.id })))
             );
           });
         });
@@ -397,7 +398,7 @@ describe('api v.1', () => {
             await user.favourited_posts().attach(post);
             await expect(
               { url: `/api/v1/posts/favoured`, session: sessionId },
-              'body to satisfy', [{ text: 'This is clean post' }]
+              'body to satisfy', [{ id: post.id }]
             );
           });
 
@@ -453,7 +454,7 @@ describe('api v.1', () => {
             await user.liked_posts().attach(post);
             await expect(
               { url: `/api/v1/posts/liked`, session: sessionId },
-              'body to satisfy', [{ text: 'This is clean post' }]
+              'body to satisfy', [{ id: post.id }]
             );
           });
 
@@ -742,7 +743,7 @@ describe('api v.1', () => {
           await post.attachHashtags(['foo']);
           await expect(
             { url: `/api/v1/posts/tag/foo` },
-            'body to satisfy', [{ text: post.get('text') }]
+            'body to satisfy', [{ id: post.id }]
           );
           await post.detachHashtags(['foo']);
         });
@@ -763,7 +764,7 @@ describe('api v.1', () => {
             await user.favourited_posts().attach(post);
             await expect(
               { url: `/api/v1/posts/favoured/${user.get('username')}` },
-              'body to satisfy', [{ text: post.get('text') }]
+              'body to satisfy', [{ id: post.id }]
             );
           });
 
@@ -792,7 +793,7 @@ describe('api v.1', () => {
             await user.liked_posts().attach(post);
             await expect(
               { url: `/api/v1/posts/liked/${user.get('username')}` },
-              'body to satisfy', [{ text: post.get('text') }]
+              'body to satisfy', [{ id: post.id }]
             );
           });
 

--- a/test/integration/api/post.js
+++ b/test/integration/api/post.js
@@ -78,8 +78,8 @@ describe('Post', () => {
 
         await expect(
           { url: `/api/v1/posts/tag/${name}`, method: 'GET' },
-          'to have body array length',
-          1
+          'body to satisfy',
+          [{ id: post.id }]
         );
       });
     });
@@ -100,8 +100,8 @@ describe('Post', () => {
 
         await expect(
           { url: `/api/v1/posts/school/${name}`, method: 'GET' },
-          'to have body array length',
-          1
+          'body to satisfy',
+          [{ id: post.id }]
         );
       });
     });
@@ -122,8 +122,8 @@ describe('Post', () => {
 
         await expect(
           { url: `/api/v1/posts/geotag/${name}`, method: 'GET' },
-          'to have body array length',
-          1
+          'body to satisfy',
+          [{ id: post.id }]
         );
       });
     });
@@ -142,8 +142,8 @@ describe('Post', () => {
       it('should not return hashtag_like posts from other authors', async () => {
         await expect(
           { url: `/api/v1/posts/liked/${user.get('username')}` },
-          'to have body array length',
-          0
+          'body to satisfy',
+          []
         );
       });
     });

--- a/test/integration/api/post.js
+++ b/test/integration/api/post.js
@@ -163,7 +163,6 @@ describe('Post', () => {
       await otherUser.destroy();
     });
 
-
     describe('POST /api/v1/posts', () => {
       it('creates a post and copies text_source into text without processing', async () => {
         await expect(
@@ -208,6 +207,27 @@ describe('Post', () => {
             {
               text_source: '# header',
               text: expect.it('to contain', '<h1>header</h1>')
+            }
+          );
+        });
+
+        it('extracts first image url into more.image.url', async () => {
+          await expect(
+            {
+              session: sessionId,
+              url: `/api/v1/posts`,
+              method: 'POST',
+              body: {
+                type: 'story',
+                text_source: '<div>Test</div><img src="http://test.com/test.png" />',
+                text_type: 'html',
+                title: 'Title'
+              }
+            },
+            'body to satisfy',
+            {
+              text: expect.it('to contain', '<div>Test</div><img src="http://test.com/test.png" />'),
+              more: { image: { url: 'http://test.com/test.png' } }
             }
           );
         });
@@ -272,8 +292,7 @@ describe('Post', () => {
           );
         });
 
-
-        it('updates post and re-renders text', async () => {
+        it('extracts first image url into more.image.url', async () => {
           await expect(
             {
               session: sessionId,
@@ -281,15 +300,15 @@ describe('Post', () => {
               method: 'POST',
               body: {
                 type: 'story',
-                text_source: '# new header 2',
-                text_type: 'markdown',
+                text_source: '<div>Test</div><img src="http://test.com/test.png" />',
+                text_type: 'html',
                 title: 'Title'
               }
             },
             'body to satisfy',
             {
-              text_source: '# new header 2',
-              text: expect.it('to contain', '<h1>new header 2</h1>')
+              text: expect.it('to contain', '<div>Test</div><img src="http://test.com/test.png" />'),
+              more: { image: { url: 'http://test.com/test.png' } }
             }
           );
         });

--- a/test/integration/api/post.js
+++ b/test/integration/api/post.js
@@ -163,6 +163,139 @@ describe('Post', () => {
       await otherUser.destroy();
     });
 
+
+    describe('POST /api/v1/posts', () => {
+      it('creates a post and copies text_source into text without processing', async () => {
+        await expect(
+          {
+            session: sessionId,
+            url: `/api/v1/posts`,
+            method: 'POST',
+            body: {
+              type: 'short_text',
+              text_source: '# header',
+              text_type: 'markdown',
+              title: 'Title'
+            }
+          },
+          'body to satisfy',
+          {
+            text_source: '# header',
+            text: '# header'
+          }
+        );
+      });
+
+      describe('story posts', () => {
+        after(async () => {
+          await knex('posts').where({ type: 'story' }).delete();
+        });
+
+        it('creates story post and processes text', async () => {
+          await expect(
+            {
+              session: sessionId,
+              url: `/api/v1/posts`,
+              method: 'POST',
+              body: {
+                type: 'story',
+                text_source: '# header',
+                text_type: 'markdown',
+                title: 'Title'
+              }
+            },
+            'body to satisfy',
+            {
+              text_source: '# header',
+              text: expect.it('to contain', '<h1>header</h1>')
+            }
+          );
+        });
+
+        describe('when text_type is not supported or not specified', () => {
+          it('returns error', async () => {
+            await expect(
+              {
+                session: sessionId,
+                url: `/api/v1/posts`,
+                method: 'POST',
+                body: {
+                  type: 'story',
+                  text_source: '# header',
+                  text_type: 'invalid type',
+                  title: 'Title'
+                }
+              },
+              'not to open',
+            );
+          });
+        });
+      });
+    });
+
+
+    describe('POST /api/v1/post/:id', () => {
+      describe('story posts', () => {
+        let post;
+        before(async () => {
+          post = await createPost({
+            user_id: user.id,
+            type: 'story',
+            text_type: 'markdown',
+            text_source: '# initial header',
+            text: '<h1>initial header</h1>'
+          });
+        });
+
+        after(async () => {
+          await post.destroy();
+        });
+
+        it('updates post and re-renders text', async () => {
+          await expect(
+            {
+              session: sessionId,
+              url: `/api/v1/post/${post.id}`,
+              method: 'POST',
+              body: {
+                type: 'story',
+                text_source: '# new header 1',
+                text_type: 'markdown',
+                title: 'Title'
+              }
+            },
+            'body to satisfy',
+            {
+              text_source: '# new header 1',
+              text: expect.it('to contain', '<h1>new header 1</h1>')
+            }
+          );
+        });
+
+
+        it('updates post and re-renders text', async () => {
+          await expect(
+            {
+              session: sessionId,
+              url: `/api/v1/post/${post.id}`,
+              method: 'POST',
+              body: {
+                type: 'story',
+                text_source: '# new header 2',
+                text_type: 'markdown',
+                title: 'Title'
+              }
+            },
+            'body to satisfy',
+            {
+              text_source: '# new header 2',
+              text: expect.it('to contain', '<h1>new header 2</h1>')
+            }
+          );
+        });
+      });
+    });
+
     describe('subscriptions', () => {
       let post;
 

--- a/test/integration/triggers/index.js
+++ b/test/integration/triggers/index.js
@@ -157,7 +157,7 @@ describe('ActionsTrigger', () => {
     it('createPost should work', async () => {
       const store = initState();
       triggers = new ActionsTrigger(client, store.dispatch);
-      await triggers.createPost('short_text', { text: 'lorem ipsum' });
+      await triggers.createPost('short_text', { text_source: 'lorem ipsum' });
 
       expect(store.getState().get('river').size, 'to equal', 1);
     });


### PR DESCRIPTION
Part of #877.

To create a story post, set `type` to `'story'` and `text_type` to either `'markdown'` or `'html'`. Next, back-end processes `text_source` according to `text_type` and outputs the result into `text`. Keep in mind that some controllers that return a collection of posts do not include `text` and `text_source` by default anymore. Add `?fields=+text,text_source` query to include those fields (prefix with `+` to extend default list of fields).

The PR also contains a complete refactoring of `createPost` and `updatePost` controllers. The motivation for this change is that it's getting harder to manage and validate all text post invariants (short_text, long_text, story). Each type of a post requires a different treatment and it makes the `createPost` and `updatePost` controllers too convoluted.

I'm also working on validation of posts using Joi. The PR may be merged as it is, I going to make a separate PR later, but for now validation errors are being sent with the `500` code instead of `400`.

- [x] Make `title` optional.
- [x] Save first image url to `more.image.url`
- [x] Save first two paragraphs of text to `more.shortText`
- [x] Exclude `text` and `text_source` columns from post lists. (all GET `/posts/*` methods)
- [x] Columns: `text_source`, `text_type`, `text`
  - [x] For non-story posts, save text into both `text_source` and `text`
  - [x] For story posts, `text` contains processed text which is safe to be rendered using `dangerouslySetInnerHTML` 
  - [x] `text_type` can only be `markdown` or `html`. No plain text.
- [ ] Fix controllers once #868 is merged.

The client side needs to be refactored to use `more.shortText` instead of `text`.