### PR TITLE
Hide Intercom's default messenger from all the pages

### DIFF
--- a/src/pages/app.js
+++ b/src/pages/app.js
@@ -90,7 +90,11 @@ export class UnwrappedApp extends React.Component {
         </Helmet>
         {children}
         {gaContent}
-        <WrappedIntercom app_id={INTERCOM_APP_ID} url={url} />
+        <WrappedIntercom
+          app_id={INTERCOM_APP_ID}
+          hide_default_launcher
+          url={url}
+        />
         <ContextualRoutes
           location={this.props.location}
           routes={this.props.routes}


### PR DESCRIPTION
Accoding to [Intercom's docs](https://docs.intercom.com/configure-intercom-for-your-product-or-site/customize-the-intercom-messenger/turning-off-the-intercom-messenger-launcher), it's possible to manage (e.g. hide) the launcher with Intercom's internal control panel.

However, [the task](https://github.com/Lokiedu/libertysoil-site/issues/882) is to hide the messenger programmaticaly:

> - [ ] Please disconnect intercom from all pages

The stats of usage will most likely be delivered but it's desirable to test that behaviour after deployment.