### PR TITLE
Recent tags (API)

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "react-router-redux": "~4.0.7",
     "react-toggle-switch": "~3.0.0",
     "react-transition-group": "~1.2.0",
+    "redis": "^2.8.0",
     "redux": "~3.7.2",
     "redux-catch": "^1.3.1",
     "redux-immutablejs": "0.0.8",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -23,6 +23,7 @@ export const tags = require('./tags');
 export const hashtags = require('./hashtags');
 export const geotags = require('./geotags');
 export const schools = require('./schools');
+export const recentTags = require('./recent-tags');
 
 export const geo = require('./geo');
 

--- a/src/actions/recent-tags.js
+++ b/src/actions/recent-tags.js
@@ -15,30 +15,13 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-import i from 'immutable';
-import _ from 'lodash';
+export const SET_RECENT_TAGS = 'SET_RECENT_TAGS';
 
-import { hashtags as h, recentTags } from '../actions';
-
-const initialState = i.Map({});
-
-export default function reducer(state = initialState, action) {
-  switch (action.type) {
-    case h.ADD_HASHTAG: {
-      const hashtag = action.payload.hashtag;
-      state = state.set(hashtag.name, i.fromJS(hashtag));
-
-      break;
+export function setRecentTags(tags) {
+  return {
+    type: SET_RECENT_TAGS,
+    payload: {
+      ...tags
     }
-
-    case recentTags.SET_RECENT_TAGS:
-    case h.SET_HASHTAGS: {
-      const hashtags = _.keyBy(action.payload.hashtags, 'name');
-      state = state.merge(i.fromJS(hashtags));
-
-      break;
-    }
-  }
-
-  return state;
+  };
 }

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -529,6 +529,11 @@ export default class ApiClient {
     return (await response.json(): Array<Geotag>);
   }
 
+  async recentlyUsedTags(): Promise<UserRecentTags> {
+    const response = await this.get('/api/v1/recent-tags');
+    return (await response.json(): UserRecentTags);
+  }
+
   async initialSuggestions(): Promise<Array<User>> {
     const response = await this.get(`/api/v1/suggestions/initial`);
     return (await response.json(): Array<User>);

--- a/src/api/controllers/geotags.js
+++ b/src/api/controllers/geotags.js
@@ -78,15 +78,10 @@ export async function searchGeotags(ctx) {
 export async function getUserRecentGeotags(ctx) {
   const Geotag = ctx.bookshelf.model('Geotag');
 
-  const geotags = await Geotag
-    .collection()
+  const geotags = await Geotag.getRecentlyUsed()
     .query(qb => {
       qb
-        .join('geotags_posts', 'geotags.id', 'geotags_posts.geotag_id')
-        .join('posts', 'geotags_posts.post_id', 'posts.id')
         .where('posts.user_id', ctx.state.user)
-        .groupBy('geotags.id')
-        .orderByRaw('MAX(posts.created_at) DESC')
         .limit(5);
     })
     .fetch();

--- a/src/api/controllers/geotags.js
+++ b/src/api/controllers/geotags.js
@@ -45,9 +45,9 @@ export async function getGeotags(ctx) {
 
   const geotags = await Geotag.collection()
     .query(qb => {
-      applyLimitQuery(qb, ctx.query, 10);
-      applyOffsetQuery(qb, ctx.query, 0);
-      applySortQuery(qb, ctx.query, 'url_name');
+      applyLimitQuery(qb, ctx.query, { defaultValue: 10 });
+      applyOffsetQuery(qb, ctx.query, { defaultValue: 0 });
+      applySortQuery(qb, ctx.query, { defaultValue: 'url_name' });
       qb.where(_.pick(ctx.query, ALLOWED_ATTRIBUTE_QUERIES));
     })
     .fetch();

--- a/src/api/controllers/hashtags.js
+++ b/src/api/controllers/hashtags.js
@@ -116,15 +116,10 @@ export async function unlikeHashtag(ctx) {
 export async function getUserRecentHashtags(ctx) {
   const Hashtag = ctx.bookshelf.model('Hashtag');
 
-  const hashtags = await Hashtag
-    .collection()
+  const hashtags = await Hashtag.getRecentlyUsed()
     .query(qb => {
       qb
-        .join('hashtags_posts', 'hashtags.id', 'hashtags_posts.hashtag_id')
-        .join('posts', 'hashtags_posts.post_id', 'posts.id')
         .where('posts.user_id', ctx.state.user)
-        .groupBy('hashtags.id')
-        .orderByRaw('MAX(posts.created_at) DESC')
         .limit(5);
     })
     .fetch();

--- a/src/api/controllers/posts.js
+++ b/src/api/controllers/posts.js
@@ -21,7 +21,7 @@ import Joi from 'joi';
 import * as PostUtils from '../utils/posts';
 import { seq } from '../../utils/lang';
 import {
-  applyFieldsQuery, applyLimitQuery, applyOffsetQuery, applySortQuery
+  applyFieldsQuery, applyLimitQuery, applyOffsetQuery, applySortQuery, applyDateRangeQuery
 } from '../utils/filters';
 import { POST_RELATIONS, POST_PUBLIC_COLUMNS, POST_DEFAULT_COLUMNS } from '../consts';
 import { PostValidator } from '../validators';
@@ -467,6 +467,7 @@ export async function allPosts(ctx) {
       allowedFields: POST_PUBLIC_COLUMNS,
       defaultFileds: POST_DEFAULT_COLUMNS
     });
+    applyDateRangeQuery(qb, ctx.query, { field: 'created_at' });
 
     if ('continent' in ctx.query) {
       qb

--- a/src/api/controllers/schools.js
+++ b/src/api/controllers/schools.js
@@ -62,7 +62,7 @@ export async function getSchools(ctx) {
   const schools = await School.collection().query(qb => {
     applyLimitQuery(qb, ctx.query);
     applyOffsetQuery(qb, ctx.query);
-    applySortQuery(qb, ctx.query, 'name');
+    applySortQuery(qb, ctx.query, { defaultValue: 'name' });
 
     if (ctx.query.havePosts) {
       qb.where('post_count', '>', 0);

--- a/src/api/controllers/schools.js
+++ b/src/api/controllers/schools.js
@@ -236,15 +236,10 @@ export async function searchSchools(ctx) {
 export async function getUserRecentSchools(ctx) {
   const School = ctx.bookshelf.model('School');
 
-  const schools = await School
-    .collection()
+  const schools = await School.getRecentlyUsed()
     .query(qb => {
       qb
-        .join('posts_schools', 'schools.id', 'posts_schools.school_id')
-        .join('posts', 'posts_schools.post_id', 'posts.id')
         .where('posts.user_id', ctx.state.user)
-        .groupBy('schools.id')
-        .orderByRaw('MAX(posts.created_at) DESC')
         .limit(5);
     })
     .fetch();

--- a/src/api/controllers/users.js
+++ b/src/api/controllers/users.js
@@ -425,7 +425,7 @@ export async function getMutualFollows(ctx) {
             .whereRaw('f2.user_id = users.id');
         });
 
-      applySortQuery(qb, ctx.query, 'username');
+      applySortQuery(qb, ctx.query, { defaultValue: 'username' });
     })
     .fetch({
       withRelated: USER_RELATIONS

--- a/src/api/db/index.js
+++ b/src/api/db/index.js
@@ -619,6 +619,19 @@ export function initBookshelfFromKnex(knex) {
       });
   };
 
+  Hashtag.getRecentlyUsed = function (opts = { limit: 5 }) {
+    return Hashtag
+      .collection()
+      .query(qb => {
+        qb
+          .join('hashtags_posts', 'hashtags.id', 'hashtags_posts.hashtag_id')
+          .join('posts', 'hashtags_posts.post_id', 'posts.id')
+          .groupBy('hashtags.id')
+          .orderByRaw('MAX(posts.created_at) DESC')
+          .limit(opts.limit);
+      });
+  };
+
   const School = bookshelf.Model.extend({
     tableName: 'schools',
     posts() {
@@ -670,6 +683,19 @@ export function initBookshelfFromKnex(knex) {
           .where('posts_schools.school_id', knex.raw('schools.id'))
           .orderBy('created_at', 'DESC')
           .limit(1)
+      });
+  };
+
+  School.getRecentlyUsed = function (opts = { limit: 5 }) {
+    return School
+      .collection()
+      .query(qb => {
+        qb
+          .join('posts_schools', 'schools.id', 'posts_schools.school_id')
+          .join('posts', 'posts_schools.post_id', 'posts.id')
+          .groupBy('schools.id')
+          .orderByRaw('MAX(posts.created_at) DESC')
+          .limit(opts.limit);
       });
   };
 
@@ -778,6 +804,19 @@ export function initBookshelfFromKnex(knex) {
           .where('geotags_posts.geotag_id', knex.raw('geotags.id'))
           .orderBy('created_at', 'DESC')
           .limit(1)
+      });
+  };
+
+  Geotag.getRecentlyUsed = function (opts = { limit: 5 }) {
+    return Geotag
+      .collection()
+      .query(qb => {
+        qb
+          .join('geotags_posts', 'geotags.id', 'geotags_posts.geotag_id')
+          .join('posts', 'geotags_posts.post_id', 'posts.id')
+          .groupBy('geotags.id')
+          .orderByRaw('MAX(posts.created_at) DESC')
+          .limit(opts.limit);
       });
   };
 

--- a/src/api/db/index.js
+++ b/src/api/db/index.js
@@ -576,6 +576,32 @@ export function initBookshelfFromKnex(knex) {
     });
   };
 
+  Post.countWithTags = async function ({ tagType, since }) {
+    const qb = knex('posts')
+      .countDistinct('posts.id');
+
+    switch (tagType) {
+      case 'hashtag': {
+        qb.join('hashtags_posts', 'hashtags_posts.post_id', 'posts.id');
+        break;
+      }
+      case 'school': {
+        qb.join('posts_schools', 'posts_schools.post_id', 'posts.id');
+        break;
+      }
+      case 'geotag': {
+        qb.join('geotags_posts', 'geotags_posts.post_id', 'posts.id');
+        break;
+      }
+    }
+
+    if (_.isDate(since)) {
+      qb.where('posts.created_at', '>=', since.toJSON());
+    }
+
+    return parseInt((await qb)[0].count, 10);
+  };
+
   const Hashtag = bookshelf.Model.extend({
     tableName: 'hashtags',
     posts() {
@@ -619,7 +645,7 @@ export function initBookshelfFromKnex(knex) {
       });
   };
 
-  Hashtag.getRecentlyUsed = function (opts = { limit: 5 }) {
+  Hashtag.getRecentlyUsed = function (opts = { limit: 5, since: null }) {
     return Hashtag
       .collection()
       .query(qb => {
@@ -627,8 +653,15 @@ export function initBookshelfFromKnex(knex) {
           .join('hashtags_posts', 'hashtags.id', 'hashtags_posts.hashtag_id')
           .join('posts', 'hashtags_posts.post_id', 'posts.id')
           .groupBy('hashtags.id')
-          .orderByRaw('MAX(posts.created_at) DESC')
-          .limit(opts.limit);
+          .orderByRaw('MAX(posts.created_at) DESC');
+
+        if (_.isNumber(opts.limit)) {
+          qb.limit(opts.limit);
+        }
+
+        if (_.isDate(opts.since)) {
+          qb.where('posts.created_at', '>=', opts.since.toJSON());
+        }
       });
   };
 
@@ -686,7 +719,7 @@ export function initBookshelfFromKnex(knex) {
       });
   };
 
-  School.getRecentlyUsed = function (opts = { limit: 5 }) {
+  School.getRecentlyUsed = function (opts = { limit: 5, since: null }) {
     return School
       .collection()
       .query(qb => {
@@ -694,8 +727,15 @@ export function initBookshelfFromKnex(knex) {
           .join('posts_schools', 'schools.id', 'posts_schools.school_id')
           .join('posts', 'posts_schools.post_id', 'posts.id')
           .groupBy('schools.id')
-          .orderByRaw('MAX(posts.created_at) DESC')
-          .limit(opts.limit);
+          .orderByRaw('MAX(posts.created_at) DESC');
+
+        if (_.isNumber(opts.limit)) {
+          qb.limit(opts.limit);
+        }
+
+        if (_.isDate(opts.since)) {
+          qb.where('posts.created_at', '>=', opts.since.toJSON());
+        }
       });
   };
 
@@ -807,7 +847,7 @@ export function initBookshelfFromKnex(knex) {
       });
   };
 
-  Geotag.getRecentlyUsed = function (opts = { limit: 5 }) {
+  Geotag.getRecentlyUsed = function (opts = { limit: 5, since: null }) {
     return Geotag
       .collection()
       .query(qb => {
@@ -815,8 +855,15 @@ export function initBookshelfFromKnex(knex) {
           .join('geotags_posts', 'geotags.id', 'geotags_posts.geotag_id')
           .join('posts', 'geotags_posts.post_id', 'posts.id')
           .groupBy('geotags.id')
-          .orderByRaw('MAX(posts.created_at) DESC')
-          .limit(opts.limit);
+          .orderByRaw('MAX(posts.created_at) DESC');
+
+        if (_.isNumber(opts.limit)) {
+          qb.limit(opts.limit);
+        }
+
+        if (_.isDate(opts.since)) {
+          qb.where('posts.created_at', '>=', opts.since.toJSON());
+        }
       });
   };
 

--- a/src/api/routing.js
+++ b/src/api/routing.js
@@ -180,6 +180,8 @@ export function initApi(bookshelf) {
   api.post('/geotag/:url_name/like', auth, geotags.likeGeotag);
   api.post('/geotag/:url_name/unlike', auth, geotags.unlikeGeotag);
 
+  api.get('/recent-tags', misc.getRecentlyUsedTags);
+
   api.get('/quotes', misc.getQuotes);
 
   api.get('/search', search.search);

--- a/src/api/utils/cache.js
+++ b/src/api/utils/cache.js
@@ -1,0 +1,57 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2015  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+export class RedisCache {
+  client = null;
+  defaultTimeout = 60 * 10; // 10 minutes
+
+  constructor(client) {
+    this.client = client;
+  }
+
+  /**
+   * Retruns a cached value if present, otherwise calls `getData`, caches and returns the result.
+   * @param {*} key Redis key
+   * @param {*} getData
+   * @param {*} timeout Cache timeout in seconds
+   */
+  async getCached(key, getData, timeout) {
+    let result = await this.client.getAsync(key);
+
+    if (!result) {
+      result = JSON.stringify(await getData());
+      this.client.setAsync(key, result, 'EX', timeout || this.defaultTimeout);
+    }
+
+    return result;
+  }
+
+  async getCachedJson(key, getData, timeout) {
+    return JSON.parse(await this.getCached(key, getData, timeout));
+  }
+}
+
+// For tests, where caching is not needed.
+export class TestCache {
+  async getCached(key, getData) {
+    return JSON.stringify(await getData());
+  }
+
+  async getCachedJson(key, getData) {
+    return JSON.parse(await this.getCached(key, getData));
+  }
+}

--- a/src/api/utils/filters.js
+++ b/src/api/utils/filters.js
@@ -33,18 +33,21 @@ export function applySortQuery(qb, query, options = {}) {
   if ('sort' in query || options.defaultValue) {
     const columns = (query.sort || options.defaultValue).split(',');
 
-    const queryString = columns.map(column => {
+    for (let column of columns) {
       let order = 'ASC';
 
       if (column[0] == '-') {
         column = column.substring(1);
+
+        if (options.table) {
+          column = `${options.table}.${column}`;
+        }
+
         order = 'DESC';
       }
 
-      return `${column} ${order}`;
-    }).join(', ');
-
-    qb.orderByRaw(queryString);
+      qb.orderBy(column, order);
+    }
   }
 }
 

--- a/src/api/utils/filters.js
+++ b/src/api/utils/filters.js
@@ -15,7 +15,13 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-import _ from 'lodash';
+import { isEmpty, uniq, intersection } from 'lodash';
+
+
+/*
+  Function signature convention:
+  applySomeQuery(qb, query, options)
+*/
 
 /**
  * Sets 'order by' for the {@link qb} depending on the 'sort' query parameter.
@@ -23,9 +29,9 @@ import _ from 'lodash';
  * @param qb Knex query builder.
  * @param {Object} query An object containing query parameters.
  */
-export async function applySortQuery(qb, query, defaultValue = null) {
-  if ('sort' in query || defaultValue) {
-    const columns = (query.sort || defaultValue).split(',');
+export function applySortQuery(qb, query, options = {}) {
+  if ('sort' in query || options.defaultValue) {
+    const columns = (query.sort || options.defaultValue).split(',');
 
     const queryString = columns.map(column => {
       let order = 'ASC';
@@ -42,21 +48,21 @@ export async function applySortQuery(qb, query, defaultValue = null) {
   }
 }
 
-export async function applyStartsWithQuery(qb, query) {
+export function applyStartsWithQuery(qb, query) {
   if ('startsWith' in query) {
     qb.where('name', 'ILIKE', `${query.startsWith}%`);
   }
 }
 
-export async function applyLimitQuery(qb, query, defaultValue = null) {
-  if ('limit' in query || defaultValue) {
-    qb.limit(query.limit || defaultValue);
+export function applyLimitQuery(qb, query, options = {}) {
+  if ('limit' in query || options.defaultValue) {
+    qb.limit(query.limit || options.defaultValue);
   }
 }
 
-export async function applyOffsetQuery(qb, query, defaultValue = null) {
-  if ('offset' in query || defaultValue) {
-    qb.offset(query.offset || defaultValue);
+export function applyOffsetQuery(qb, query, options = {}) {
+  if ('offset' in query || options.defaultValue) {
+    qb.offset(query.offset || options.defaultValue);
   }
 }
 
@@ -65,19 +71,19 @@ export async function applyOffsetQuery(qb, query, defaultValue = null) {
  *   ?fields=id,name
  *   ?fields=+id,name - to extend default
  */
-export async function applyFieldsQuery(qb, query, allowedFields, defaultFields = null, table = null) {
+export function applyFieldsQuery(qb, query, { allowedFields, defaultFields, table = null }) {
   let fields = defaultFields;
-  if (!_.isEmpty(query.fields)) {
+  if (!isEmpty(query.fields)) {
     fields = query.fields.split(',');
 
     if (query.fields[0] == '+' && defaultFields) {
-      fields = _.uniq(fields.concat(defaultFields));
+      fields = uniq(fields.concat(defaultFields));
     }
 
-    fields = _.intersection(fields, allowedFields);
+    fields = intersection(fields, allowedFields);
   }
 
-  if (table) {
+  if (fields && table) {
     fields = fields.map(col => `${table}.${col}`);
   }
 

--- a/src/api/utils/filters.js
+++ b/src/api/utils/filters.js
@@ -92,6 +92,15 @@ export function applyFieldsQuery(qb, query, { allowedFields, defaultFields, tabl
   }
 }
 
+/**
+ * Format:
+ *   [upper bound]..[lower bound]
+ * Examples:
+ *  ?dateRange=2017-09-30T22:00:00.000Z..2017-09-29T22:00:00.000Z
+ *  ?dateRange=..2017-09-29T22:00:00.000Z
+ *  ?dateRange=2017-09-30T22:00:00.000Z..
+ * The format of dates may be anything accepted by the Date controller. Both bounds are inclusive.
+ */
 export function applyDateRangeQuery(qb, query, options) {
   const { field, paramName } = {
     paramName: 'dateRange',

--- a/src/api/utils/filters.js
+++ b/src/api/utils/filters.js
@@ -15,7 +15,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-import { isEmpty, isString, uniq, intersection } from 'lodash';
+import { isEmpty, isString, uniq, intersection, clamp } from 'lodash';
 
 
 /*
@@ -58,8 +58,13 @@ export function applyStartsWithQuery(qb, query) {
 }
 
 export function applyLimitQuery(qb, query, options = {}) {
-  if ('limit' in query || options.defaultValue) {
-    qb.limit(query.limit || options.defaultValue);
+  let value = query.limit || options.defaultValue;
+  if (value) {
+    if (options.max) {
+      value = clamp(value, options.min || 0, options.max);
+    }
+
+    qb.limit(value);
   }
 }
 

--- a/src/api/utils/filters.js
+++ b/src/api/utils/filters.js
@@ -15,7 +15,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-import { isEmpty, uniq, intersection } from 'lodash';
+import { isEmpty, isString, uniq, intersection } from 'lodash';
 
 
 /*
@@ -89,5 +89,28 @@ export function applyFieldsQuery(qb, query, { allowedFields, defaultFields, tabl
 
   if (fields) {
     qb.select(fields);
+  }
+}
+
+export function applyDateRangeQuery(qb, query, options) {
+  const { field, paramName } = {
+    paramName: 'dateRange',
+    ...options,
+  };
+
+  if (!isString(query[paramName])) {
+    return;
+  }
+
+  const [lhs, rhs] = query[paramName]
+    .split('..')
+    .map(date => new Date(date));
+
+  if (!isNaN(lhs.getTime())) {
+    qb.where(field, '<=', lhs);
+  }
+
+  if (!isNaN(rhs.getTime())) {
+    qb.where(field, '>=', rhs);
   }
 }

--- a/src/pages/all-geotags.js
+++ b/src/pages/all-geotags.js
@@ -60,7 +60,7 @@ class GeotagCloudPage extends Component {
 
     await Promise.all([
       triggers.loadGeotags({ type: 'Continent', sort: 'url_name' }),
-      triggers.loadAllPosts({ ...router.location.query, geotags: true }),
+      triggers.loadAllPosts({ ...router.location.query, tagType: 'geotag' }),
       triggers.loadGeotagCloud()
     ]);
   }
@@ -76,7 +76,7 @@ class GeotagCloudPage extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (!isEqual(this.props.location.query, nextProps.location.query)) {
-      this.triggers.loadAllPosts({ ...nextProps.location.query, geotags: true });
+      this.triggers.loadAllPosts({ ...nextProps.location.query, tagType: 'geotag' });
     }
   }
 
@@ -86,7 +86,7 @@ class GeotagCloudPage extends Component {
 
   handleForceLoadPosts = async () => {
     const { river, location } = this.props;
-    const query = { ...location.query, geotags: true, offset: river.size };
+    const query = { ...location.query, tagType: 'geotag', offset: river.size };
     const res = await this.triggers.loadAllPosts(query);
     return Array.isArray(res) && res.length > LOAD_MORE_LIMIT;
   };
@@ -99,7 +99,7 @@ class GeotagCloudPage extends Component {
     const { river, location, ui } = this.props;
     let displayLoadMore = true;
     if (!ui.getIn(['progress', 'loadAllPostsInProgress'])) {
-      const query = { ...location.query, geotags: true, offset: river.size };
+      const query = { ...location.query, tagType: 'geotag', offset: river.size };
       const res = await this.triggers.loadAllPosts(query);
       displayLoadMore = Array.isArray(res) && res.length > LOAD_MORE_LIMIT;
     }

--- a/src/store/geotags.js
+++ b/src/store/geotags.js
@@ -18,7 +18,7 @@
 import i from 'immutable';
 import { concat, keyBy } from 'lodash';
 
-import { geotags as g } from '../actions';
+import { geotags as g, recentTags } from '../actions';
 
 const initialState = i.Map({});
 
@@ -47,6 +47,7 @@ export default function reducer(state = initialState, action) {
       break;
     }
 
+    case recentTags.SET_RECENT_TAGS:
     case g.SET_GEOTAGS: {
       const geotags = keyBy(action.payload.geotags, 'url_name');
       state = i.fromJS(geotags);

--- a/src/store/recent_tags.js
+++ b/src/store/recent_tags.js
@@ -16,41 +16,33 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 import i from 'immutable';
-import { keyBy } from 'lodash';
+import { map } from 'lodash';
+import { recentTags } from '../actions';
 
-import { schools as s, recentTags } from '../actions';
+export const initialState = i.fromJS({
+  hashtags: [],
+  schools: [],
+  geotags: [],
+});
 
-function cleanupSchoolObject(school) {
-  if (school.description === null) {
-    school.description = '';
-  }
-
-  if (school.lat === null) {
-    school.lat = 0.0;
-  }
-
-  if (school.lon === null) {
-    school.lon = 0.0;
-  }
-
-  return school;
-}
-
-const initialState = i.Map({});
-
-export default function reducer(state = initialState, action) {
+export function reducer(state = initialState, action) {
   switch (action.type) {
-    case s.ADD_SCHOOL: {
-      const school = cleanupSchoolObject(action.payload.school);
-      state = state.set(school.id, i.fromJS(school));
+    case recentTags.SET_RECENT_TAGS: {
+      const tags = {};
 
-      break;
-    }
+      if (action.payload.hashtags) {
+        tags.hashtags = map(action.payload.hashtags, 'name');
+      }
 
-    case recentTags.SET_RECENT_TAGS:
-    case s.SET_SCHOOLS: {
-      const schools = keyBy(action.payload.schools.map(school => cleanupSchoolObject(school)), 'id');
-      state = state.merge(i.fromJS(schools));
+      if (action.payload.schools) {
+        tags.schools = map(action.payload.schools, 'id');
+      }
+
+      if (action.payload.geotags) {
+        tags.geotags = map(action.payload.geotags, 'url_name');
+      }
+
+      state = state.merge(i.fromJS(tags));
 
       break;
     }

--- a/src/triggers/index.js
+++ b/src/triggers/index.js
@@ -468,6 +468,15 @@ export class ActionsTrigger {
     }
   };
 
+  loadRecentlyUsedTags = async () => {
+    try {
+      const result = await this.client.recentlyUsedTags();
+      this.dispatch(a.tags.setUserRecentTags(result));
+    } catch (e) {
+      this.dispatch(a.messages.reportError(a.tags.SET_USER_RECENT_TAGS, e.message, { display: true }));
+    }
+  }
+
   updatePost = async (post_uuid, post_fields) => {
     try {
       const result = await this.client.updatePost(post_uuid, post_fields);

--- a/src/triggers/index.js
+++ b/src/triggers/index.js
@@ -623,9 +623,9 @@ export class ActionsTrigger {
       result = await this.client.allPosts(query);
 
       if (query.offset && query.offset > 0) {
-        this.dispatch(a.allPosts.addPosts(result));
+        this.dispatch(a.allPosts.addPosts(result.posts));
       } else {
-        this.dispatch(a.allPosts.setPosts(result));
+        this.dispatch(a.allPosts.setPosts(result.posts));
       }
     } catch (e) {
       this.dispatch(a.messages.addError(e.message));
@@ -648,9 +648,9 @@ export class ActionsTrigger {
       });
 
       if (query.offset && query.offset > 0) {
-        this.dispatch(a.mostLikedPosts.addPosts(result));
+        this.dispatch(a.mostLikedPosts.addPosts(result.posts));
       } else {
-        this.dispatch(a.mostLikedPosts.setPosts(result));
+        this.dispatch(a.mostLikedPosts.setPosts(result.posts));
       }
     } catch (e) {
       this.dispatch(a.messages.addError(e.message));
@@ -673,9 +673,9 @@ export class ActionsTrigger {
       });
 
       if (query.offset && query.offset > 0) {
-        this.dispatch(a.mostFavouritedPosts.addPosts(result));
+        this.dispatch(a.mostFavouritedPosts.addPosts(result.posts));
       } else {
-        this.dispatch(a.mostFavouritedPosts.setPosts(result));
+        this.dispatch(a.mostFavouritedPosts.setPosts(result.posts));
       }
     } catch (e) {
       this.dispatch(a.messages.addError(e.message));
@@ -698,9 +698,9 @@ export class ActionsTrigger {
       });
 
       if (query.offset && query.offset > 0) {
-        this.dispatch(a.bestPosts.addPosts(result));
+        this.dispatch(a.bestPosts.addPosts(result.posts));
       } else {
-        this.dispatch(a.bestPosts.setPosts(result));
+        this.dispatch(a.bestPosts.setPosts(result.posts));
       }
     } catch (e) {
       this.dispatch(a.messages.addError(e.message));

--- a/test-helpers/expect.js
+++ b/test-helpers/expect.js
@@ -5,6 +5,7 @@ import 'mock-aws';
 import sinon from 'sinon';
 
 import initBookshelf from '../src/api/db';
+import { TestCache } from '../src/api/utils/cache';
 
 global.$bookshelf = initBookshelf(global.$dbConfig);
 
@@ -19,6 +20,8 @@ sinon.stub(app.context.sphinx.ql, 'insert').returns({
     toString: sinon.stub().returns('insert into')
   })
 });
+
+app.context.cache = new TestCache;
 
 expect.installPlugin(require('unexpected-http'));
 expect.installPlugin(require('unexpected-dom'));

--- a/test-helpers/factories/comment.js
+++ b/test-helpers/factories/comment.js
@@ -35,13 +35,13 @@ export async function createComment(attrs = {}) {
     .save(null, { method: 'insert' });
 }
 
-export async function createHashtags(attrs) {
+export async function createComments(attrs) {
   if (typeof attrs === 'number') {
     attrs = Array.apply(null, Array(attrs));
   }
 
   const fullAttrs = attrs.map(attrs => CommentFactory.build(attrs));
-  const ids = await knex.batchInsert('posts', fullAttrs).returning('id');
+  const ids = await knex.batchInsert('comments', fullAttrs).returning('id');
   const comments = await Comment.collection().query(qb => qb.whereIn('id', ids)).fetch({ require: true });
 
   return comments.toArray();

--- a/test-helpers/factories/school.js
+++ b/test-helpers/factories/school.js
@@ -8,8 +8,7 @@ import { bookshelf, knex } from '../db';
 const School = bookshelf.model('School');
 
 const SchoolFactory = new Factory()
-  // toLowerCase is important to eliminate the difference between pg and js string sorting.
-  .attr('name', () => faker.company.companyName(0).toLowerCase())
+  .attr('name', () => faker.lorem.words(3))
   .attr('url_name', ['name'], (name) => slug(name))
   .attr('created_at', () => faker.date.past())
   .attr('updated_at', ['created_at'], (date) => date);

--- a/test-helpers/factories/school.js
+++ b/test-helpers/factories/school.js
@@ -8,7 +8,7 @@ import { bookshelf, knex } from '../db';
 const School = bookshelf.model('School');
 
 const SchoolFactory = new Factory()
-  .attr('name', () => faker.lorem.words(3))
+  .attr('name', () => `${faker.random.number()} ${faker.lorem.words(3)}`)
   .attr('url_name', ['name'], (name) => slug(name))
   .attr('created_at', () => faker.date.past())
   .attr('updated_at', ['created_at'], (date) => date);

--- a/test-helpers/factories/user.js
+++ b/test-helpers/factories/user.js
@@ -18,11 +18,11 @@ const UserFactory = new Factory()
   .attr('password', () => faker.internet.password())
   .attr('hashed_password', ['password'], password => bcrypt.hashSync(password, 10))
   .attr('email_check_hash', () => Math.random().toString())
-  .attr('more', {
+  .attr('more', () => ({
     firstName: faker.name.firstName(),
     lastName: faker.name.lastName(),
     first_login: false
-  });
+  }));
 
 export default UserFactory;
 

--- a/test/integration/api/misc.js
+++ b/test/integration/api/misc.js
@@ -25,10 +25,10 @@ import { sortBy } from 'lodash';
 import expect from '../../../test-helpers/expect';
 import { login } from '../../../test-helpers/api';
 import { createUser } from '../../../test-helpers/factories/user';
-import { createPost } from '../../../test-helpers/factories/post';
-import { createHashtag } from '../../../test-helpers/factories/hashtag';
-import { createSchool } from '../../../test-helpers/factories/school';
-import { createGeotag } from '../../../test-helpers/factories/geotag';
+import { createPost, createPosts } from '../../../test-helpers/factories/post';
+import { createHashtag, createHashtags } from '../../../test-helpers/factories/hashtag';
+import { createSchool, createSchools } from '../../../test-helpers/factories/school';
+import { createGeotag, createGeotags } from '../../../test-helpers/factories/geotag';
 import { bookshelf, knex } from '../../../test-helpers/db';
 
 const readFileAsync = bb.promisify(readFile);
@@ -129,6 +129,57 @@ describe('other controllers', () => {
           hashtags: [{ id: hashtag.id }],
           schools: [{ id: school.id }],
           geotags: [{ id: geotag.id }],
+        }
+      );
+    });
+  });
+
+  describe('GET /api/v1/recent-tags', () => {
+    let posts, hashtagIds, schoolIds, geotagIds;
+
+    before(async () => {
+      posts = await createPosts(
+        Array.apply(null, Array(5))
+          .map((_, i) => ({ created_at: new Date(Date.UTC(2017, 11, i)) }))
+      );
+      hashtagIds = (await createHashtags(6)).map(t => t.id);
+      schoolIds = (await createSchools(6)).map(t => t.id);
+      geotagIds = (await createGeotags(6)).map(t => t.id);
+
+      for (const [i, post] of posts.entries()) {
+        await post.hashtags().attach(hashtagIds[i]);
+        await post.schools().attach(schoolIds[i]);
+        await post.geotags().attach(geotagIds[i]);
+      }
+    });
+
+    after(async () => {
+      await knex('hashtags').whereIn('id', hashtagIds).del();
+      await knex('schools').whereIn('id', schoolIds).del();
+      await knex('geotags').whereIn('id', geotagIds).del();
+      await knex('posts').whereIn('id', posts.map(post => post.id)).del();
+    });
+
+    it('responds with 5 recently used tags of all types', async () => {
+      await expect(
+        {
+          method: 'GET',
+          url: `/api/v1/recent-tags`
+        },
+        'body to satisfy',
+        {
+          hashtags: {
+            entries: hashtagIds.slice(0, 5).reverse().map(id => ({ id })),
+            post_count: 0, // only counts posts created withing last 24 hours
+          },
+          schools: {
+            entries: schoolIds.slice(0, 5).reverse().map(id => ({ id })),
+            post_count: 0,
+          },
+          geotags: {
+            entries: geotagIds.slice(0, 5).reverse().map(id => ({ id })),
+            post_count: 0,
+          }
         }
       );
     });

--- a/test/unit/controllers/filters.js
+++ b/test/unit/controllers/filters.js
@@ -1,0 +1,71 @@
+/*
+ This file is a part of libertysoil.org website
+ Copyright (C) 2015  Loki Education (Social Enterprise)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-env node, mocha */
+import sinon from 'sinon';
+
+import { expect } from '../../../test-helpers/expect-unit';
+import { applyDateRangeQuery } from '../../../src/api/utils/filters';
+
+describe('Filter helpers', () => {
+  describe('applyDateRangeQuery', () => {
+    const qb = {
+      where: sinon.stub(),
+    };
+
+    afterEach(() => {
+      qb.where.reset();
+    });
+
+    context('both operands are present', () => {
+      it('calls where on qb', () => {
+        applyDateRangeQuery(qb, {
+          dateRange: '2017-09-30T22:00:00.000Z..2017-09-29T22:00:00.000Z'
+        }, { field: 'some_field' });
+
+        expect(qb.where, 'to have calls satisfying', () => {
+          qb.where('some_field', '<=', new Date('2017-09-30T22:00:00.000Z'));
+          qb.where('some_field', '>=', new Date('2017-09-29T22:00:00.000Z'));
+        });
+      });
+    });
+
+    context('left operand is not present', () => {
+      it('calls where on qb', () => {
+        applyDateRangeQuery(qb, {
+          dateRange: '2017-09-30T22:00:00.000Z..'
+        }, { field: 'some_field' });
+
+        expect(qb.where, 'to have calls satisfying', () => {
+          qb.where('some_field', '<=', new Date('2017-09-30T22:00:00.000Z'));
+        });
+      });
+    });
+
+    context('right operand is not present', () => {
+      it('calls where on qb', () => {
+        applyDateRangeQuery(qb, {
+          dateRange: '..2017-09-29T22:00:00.000Z'
+        }, { field: 'some_field' });
+
+        expect(qb.where, 'to have calls satisfying', () => {
+          qb.where('some_field', '>=', new Date('2017-09-29T22:00:00.000Z'));
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
#951

- [x] Add `getRecentlyUsedTags` controller (`/api/v1/recent-tags`). Cached with redis.
- [x] Implement redis caching.
- [x] Add redux store.
- [x] Add controller tests.
- [x] Extend `allPosts`:
    - [x] total post count (`totalCount` query param)
    - [x] `tagType` filter
    - [x] `dateRange` filter
- [x] Add counters to `getRecentlyUsedTags`.